### PR TITLE
feat: dashboard UI, subscription expiry, and toggle switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,11 @@ tmp/
 .env.local
 startOS-context.md
 deploy-sideload.sh
+
+# Python cache & temp
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+test_spec.json
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /app
 # Copy application files
 COPY bridge.py .
 COPY docker_entrypoint.sh .
+COPY web/ web/
 RUN chmod +x docker_entrypoint.sh
 
 # StartOS data persistence directory

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKG_ID := tunnelsats
-PKG_VERSION := 0.1.0
+PKG_VERSION := 0.2.0
 PLATFORM ?= $(shell uname -m)
 
 # Detect architecture

--- a/bridge.py
+++ b/bridge.py
@@ -232,9 +232,17 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             # Prevent unauthorized container-to-container scraping from within the same network
             client_ip = self.client_address[0]
             is_local = client_ip in ("127.0.0.1", "::1", "localhost")
-            has_proxy_headers = "x-forwarded-for" in self.headers or "x-forwarded-host" in self.headers
             
-            # Non-local requests must go through the StartOS HTTP reverse proxy
+            # Identify the unspoofable network gateway IP (the reverse proxy host gateway)
+            gateway_ip = get_default_gateway()
+            is_trusted_proxy = (gateway_ip and client_ip == gateway_ip)
+            
+            # Enforce that remote connections must only originate from the host gateway
+            if not is_local and not is_trusted_proxy:
+                self.send_error(403, "Access denied")
+                return
+
+            has_proxy_headers = "x-forwarded-for" in self.headers or "x-forwarded-host" in self.headers
             if not is_local and not has_proxy_headers:
                 self.send_error(403, "Access denied")
                 return

--- a/bridge.py
+++ b/bridge.py
@@ -42,7 +42,7 @@ def lazy_sync(wg_pubkey):
         data=data,
         headers={
             "Content-Type": "application/json",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            "User-Agent": "tunnelsats-startos/0.2.0"
         },
         method="POST"
     )
@@ -178,7 +178,6 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
         if self.path == "/api/status":
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
-            self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
             
             status_data = get_status()
@@ -276,12 +275,6 @@ def web_server_thread():
         server.serve_forever()
     except Exception as e:
         print(f"Failed to start web server on port 80: {e}", file=sys.stderr)
-        try:
-            server = ThreadingHTTPServer(("0.0.0.0", 8000), DashboardHTTPRequestHandler)
-            print("Web UI Dashboard server fallback running on port 8000...")
-            server.serve_forever()
-        except Exception as e2:
-            print(f"Failed to start fallback web server: {e2}", file=sys.stderr)
 
 def is_enabled():
     try:

--- a/bridge.py
+++ b/bridge.py
@@ -289,10 +289,18 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             host_header = self.headers.get("Host", "").lower()
             if is_local:
                 allowed_suffixes = ("localhost", "127.0.0.1", "[::1]")
+                is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
             else:
                 allowed_suffixes = (".local", ".lan", ".onion")
-                
-            is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
+                is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
+                if not is_allowed_host:
+                    host_name = host_header.partition(':')[0]
+                    import ipaddress
+                    try:
+                        is_allowed_host = ipaddress.ip_address(host_name).is_private
+                    except ValueError:
+                        pass
+            
             if not is_allowed_host:
                 self.send_error(403, "Access denied")
                 return

--- a/bridge.py
+++ b/bridge.py
@@ -388,9 +388,13 @@ def is_enabled():
                 if mtime != _enabled_cache_mtime:
                     with open(APP_CONFIG_PATH, 'r') as f:
                         config_data = json.load(f)
-                    _enabled_cache = config_data.get("enabled", False)
+                    if "enabled" in config_data:
+                        _enabled_cache = config_data["enabled"]
+                    else:
+                        _enabled_cache = None
                     _enabled_cache_mtime = mtime
-                return _enabled_cache
+                if _enabled_cache is not None:
+                    return _enabled_cache
             except Exception:
                 pass
         # Default to True if a v3 config exists (upgrade path/existing configurations)

--- a/bridge.py
+++ b/bridge.py
@@ -19,6 +19,9 @@ APP_CONFIG_PATH = os.path.join(DATA_DIR, "config.json")
 META_FILE_PATH = os.path.join(DATA_DIR, "tunnelsats-meta.json")
 TUNNELSATS_API_URL = "https://tunnelsats.com/api/public/v1"
 
+_enabled_cache = None
+_enabled_cache_mtime = 0
+
 def parse_config_comments(config_content):
     meta = {}
     for line in config_content.splitlines():
@@ -99,13 +102,19 @@ def lazy_sync(wg_pubkey):
 
         response_data = None
         api_success = False
+        import urllib.error
         for attempt in range(5):
             try:
                 with urllib.request.urlopen(req, timeout=10) as response:
-                    if response.status == 200:
-                        response_data = json.loads(response.read().decode("utf-8"))
-                        api_success = True
-                        break
+                    response_data = json.loads(response.read().decode("utf-8"))
+                    api_success = True
+                    break
+            except urllib.error.HTTPError as e:
+                if 400 <= e.code < 500:
+                    raise e
+                if attempt == 4:
+                    raise e
+                time.sleep(5)
             except Exception as e:
                 if attempt == 4:
                     raise e
@@ -231,6 +240,8 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
         if path_only == "/api/status":
             # Prevent unauthorized container-to-container scraping from within the same network
             client_ip = self.client_address[0]
+            if client_ip.startswith("::ffff:"):
+                client_ip = client_ip[7:]
             is_local = client_ip in ("127.0.0.1", "::1", "localhost")
             
             # Identify the unspoofable network gateway IP (the reverse proxy host gateway)
@@ -359,12 +370,19 @@ def web_server_thread():
         print(f"Failed to start web server on port 80: {e}", file=sys.stderr)
 
 def is_enabled():
+    global _enabled_cache, _enabled_cache_mtime
     try:
         if os.path.exists(APP_CONFIG_PATH):
-            with open(APP_CONFIG_PATH, 'r') as f:
-                config_data = json.load(f)
-                if "enabled" in config_data:
-                    return config_data["enabled"]
+            try:
+                mtime = os.path.getmtime(APP_CONFIG_PATH)
+                if mtime != _enabled_cache_mtime:
+                    with open(APP_CONFIG_PATH, 'r') as f:
+                        config_data = json.load(f)
+                    _enabled_cache = config_data.get("enabled", False)
+                    _enabled_cache_mtime = mtime
+                return _enabled_cache
+            except Exception:
+                pass
         # Default to True if a v3 config exists (upgrade path/existing configurations)
         if os.path.exists(CONFIG_PATH):
             return True

--- a/bridge.py
+++ b/bridge.py
@@ -215,9 +215,14 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         path_only = self.path.partition('?')[0].partition('#')[0]
         if path_only == "/api/status":
-            # Prevent unauthorized container-to-container scraping from within the same Podman network
-            host_header = self.headers.get("Host", "")
-            if "tunnelsats.embassy" in host_header.lower():
+            # Prevent unauthorized container-to-container scraping from within the same network
+            client_ip = self.client_address[0]
+            is_local = client_ip in ("127.0.0.1", "::1", "localhost")
+            host_header = self.headers.get("Host", "").lower()
+            allowed_suffixes = (".local", ".lan", ".onion", "localhost", "127.0.0.1", "[::1]")
+            is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
+            
+            if not is_local and not is_allowed_host:
                 self.send_error(403, "Access denied")
                 return
 

--- a/bridge.py
+++ b/bridge.py
@@ -219,13 +219,23 @@ def subscription_sync_loop():
                     except Exception:
                         pass
             
+            sync_success = False
             if pubkey and pubkey != "Unknown":
                 lazy_sync(pubkey)
+                if os.path.exists(META_FILE_PATH):
+                    try:
+                        with open(META_FILE_PATH, 'r') as f:
+                            meta = json.load(f)
+                        if meta.get("expiresAt"):
+                            sync_success = True
+                    except Exception:
+                        pass
         except Exception as e:
             print(f"Error in subscription sync loop: {e}", file=sys.stderr)
         
         try:
-            time.sleep(86400)
+            sleep_time = 86400 if sync_success else 300
+            time.sleep(sleep_time)
         except KeyboardInterrupt:
             break
 
@@ -330,13 +340,13 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             self.wfile.write(json.dumps(response).encode("utf-8"))
             return
 
-        web_dir = os.path.join(os.path.dirname(__file__), "web")
+        web_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "web"))
         target_path = path_only.lstrip("/")
         if not target_path or target_path == "":
             target_path = "index.html"
             
         safe_path = os.path.abspath(os.path.join(web_dir, target_path))
-        if os.path.commonpath([web_dir, safe_path]) != os.path.abspath(web_dir):
+        if os.path.commonpath([web_dir, safe_path]) != web_dir:
             self.send_error(403, "Access denied")
             return
 
@@ -860,8 +870,7 @@ def main():
                         sys.exit(1)
                 
                 # 1. Save the JSON config for future "get" calls
-                with open(APP_CONFIG_PATH, 'w') as f:
-                    json.dump(config_data, f, indent=2)
+                atomic_write_json(APP_CONFIG_PATH, config_data)
                 
                 # 2. Extract the .conf blob and write it to the WireGuard path
                 if wg_conf:

--- a/bridge.py
+++ b/bridge.py
@@ -57,6 +57,8 @@ def atomic_write_json(filepath, data):
         raise e
 
 def get_default_gateway():
+    if hasattr(get_default_gateway, "_cache"):
+        return get_default_gateway._cache
     try:
         with open("/proc/net/route", "r") as f:
             for line in f.read().splitlines()[1:]:
@@ -65,10 +67,24 @@ def get_default_gateway():
                     hex_gw = parts[2]
                     octets = [int(hex_gw[i:i+2], 16) for i in range(0, 8, 2)]
                     octets.reverse()
-                    return ".".join(map(str, octets))
+                    get_default_gateway._cache = ".".join(map(str, octets))
+                    return get_default_gateway._cache
     except Exception:
         pass
     return None
+
+def get_wg_pubkey():
+    if os.path.exists(CONFIG_PATH):
+        try:
+            with open(CONFIG_PATH, 'r') as f:
+                config_content = f.read()
+            private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
+            if private_key_match:
+                proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
+                return proc.stdout.decode().strip()
+        except Exception:
+            pass
+    return "Unknown"
 
 def lazy_sync(wg_pubkey):
     if not wg_pubkey or wg_pubkey == "Unknown" or wg_pubkey == "Not available":
@@ -207,17 +223,7 @@ def subscription_sync_loop():
         return
     while True:
         try:
-            pubkey = "Unknown"
-            if os.path.exists(CONFIG_PATH):
-                with open(CONFIG_PATH, 'r') as f:
-                    config_content = f.read()
-                private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
-                if private_key_match:
-                    try:
-                        proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
-                        pubkey = proc.stdout.decode().strip()
-                    except Exception:
-                        pass
+            pubkey = get_wg_pubkey()
             
             sync_success = False
             if pubkey and pubkey != "Unknown":
@@ -254,11 +260,17 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
                 client_ip = client_ip[7:]
             is_local = client_ip in ("127.0.0.1", "::1", "localhost")
             
-            # Identify the unspoofable network gateway IP (the reverse proxy host gateway)
+            # Identify the network gateway IP
             gateway_ip = get_default_gateway()
-            is_trusted_proxy = (gateway_ip and client_ip == gateway_ip)
             
-            # Enforce that remote connections must only originate from the host gateway
+            # Enforce that remote connections must only originate from the same /24 subnet as the gateway
+            is_trusted_proxy = False
+            if gateway_ip:
+                g_parts = gateway_ip.split('.')
+                c_parts = client_ip.split('.')
+                if len(g_parts) >= 3 and len(c_parts) >= 3:
+                    is_trusted_proxy = (g_parts[0] == c_parts[0] and g_parts[1] == c_parts[1] and g_parts[2] == c_parts[2])
+            
             if not is_local and not is_trusted_proxy:
                 self.send_error(403, "Access denied")
                 return
@@ -285,17 +297,7 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             
             status_data = get_status()
             
-            pubkey = "Unknown"
-            if os.path.exists(CONFIG_PATH):
-                try:
-                    with open(CONFIG_PATH, 'r') as f:
-                        config_content = f.read()
-                    private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
-                    if private_key_match:
-                        proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
-                        pubkey = proc.stdout.decode().strip()
-                except Exception:
-                    pass
+            pubkey = get_wg_pubkey()
             
             expiry = "Unknown"
             if os.path.exists(META_FILE_PATH):
@@ -618,14 +620,7 @@ def get_properties():
         endpoint_match = re.search(r'^\s*(?!#|;)\s*Endpoint\s*=\s*([^:\s]+):\d+', config_content, re.IGNORECASE | re.MULTILINE)
         public_ip = endpoint_match.group(1) if endpoint_match else "Unknown"
         
-        private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
-        pubkey = "Unknown"
-        if private_key_match:
-            try:
-                proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
-                pubkey = proc.stdout.decode().strip()
-            except Exception:
-                pass
+        pubkey = get_wg_pubkey()
                 
         wg_ip = get_wg_ip()
         internal_octet = wg_ip.split('.')[-1] if wg_ip else "Unknown"

--- a/bridge.py
+++ b/bridge.py
@@ -7,6 +7,7 @@ import subprocess
 import signal
 import time
 import socket
+from datetime import datetime, timezone
 
 wireproxy_process = None
 
@@ -15,6 +16,282 @@ DATA_DIR = os.getenv("DATA_DIR", "/data")
 CONFIG_PATH = os.path.join(DATA_DIR, "tunnelsatsv3.conf")
 WIREPROXY_CONFIG_PATH = os.path.join(DATA_DIR, "wireproxy.conf")
 APP_CONFIG_PATH = os.path.join(DATA_DIR, "config.json")
+META_FILE_PATH = os.path.join(DATA_DIR, "tunnelsats-meta.json")
+TUNNELSATS_API_URL = "https://tunnelsats.com/api/public/v1"
+
+def parse_config_comments(config_content):
+    meta = {}
+    for line in config_content.splitlines():
+        line = line.strip()
+        if match := re.match(r"^#\s*Valid Until:\s*(.+)", line, re.IGNORECASE):
+            meta["expiresAt"] = match.group(1).strip()
+        elif match := re.match(r"^#\s*(?:VPNPort|Port Forwarding):\s*(\d+)", line, re.IGNORECASE):
+            meta["vpnPort"] = int(match.group(1))
+    return meta
+
+def lazy_sync(wg_pubkey):
+    if not wg_pubkey or wg_pubkey == "Unknown" or wg_pubkey == "Not available":
+        return
+
+    import urllib.request
+    import urllib.error
+    url = f"{TUNNELSATS_API_URL}/subscription/status"
+    data = json.dumps({"wgPublicKey": wg_pubkey}).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        },
+        method="POST"
+    )
+    
+    meta = {}
+    try:
+        # Load existing metadata if it exists
+        if os.path.exists(META_FILE_PATH):
+            try:
+                with open(META_FILE_PATH, 'r') as f:
+                    meta = json.load(f)
+            except Exception:
+                pass
+
+        with urllib.request.urlopen(req, timeout=10) as response:
+            if response.status == 200:
+                res_data = json.loads(response.read().decode("utf-8"))
+                if isinstance(res_data, dict):
+                    expiry = res_data.get("expiry")
+                    if expiry:
+                        meta["expiresAt"] = expiry
+                    
+                    server_domain = res_data.get("server_domain")
+                    if server_domain:
+                        meta["serverDomain"] = server_domain
+                    
+                    vpn_port = res_data.get("vpn_port")
+                    if vpn_port:
+                        meta["vpnPort"] = vpn_port
+
+        # Fallback to comments parsing if config file exists and we don't have expiresAt
+        if not meta.get("expiresAt") and os.path.exists(CONFIG_PATH):
+            try:
+                with open(CONFIG_PATH, 'r') as f:
+                    config_content = f.read()
+                parsed = parse_config_comments(config_content)
+                if parsed.get("expiresAt"):
+                    meta["expiresAt"] = parsed["expiresAt"]
+            except Exception:
+                pass
+
+        # Write metadata back
+        with open(META_FILE_PATH, 'w') as f:
+            json.dump(meta, f, indent=2)
+            
+    except Exception as e:
+        print(f"Error during lazy subscription sync: {e}", file=sys.stderr)
+        
+        # Fallback to comments parsing on error if file does not have expiry
+        if not meta.get("expiresAt") and os.path.exists(CONFIG_PATH):
+            try:
+                with open(CONFIG_PATH, 'r') as f:
+                    config_content = f.read()
+                parsed = parse_config_comments(config_content)
+                if parsed.get("expiresAt"):
+                    meta["expiresAt"] = parsed["expiresAt"]
+                    with open(META_FILE_PATH, 'w') as f:
+                        json.dump(meta, f, indent=2)
+            except Exception:
+                pass
+
+def format_subscription_expiry():
+    if not os.path.exists(META_FILE_PATH):
+        return "Unknown"
+    
+    try:
+        with open(META_FILE_PATH, 'r') as f:
+            meta = json.load(f)
+        expires_at = meta.get("expiresAt")
+        if not expires_at:
+            return "Unknown"
+            
+        try:
+            expiry_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+            if expiry_dt.tzinfo is None:
+                expiry_dt = expiry_dt.replace(tzinfo=timezone.utc)
+            
+            now = datetime.now(timezone.utc)
+            if expiry_dt < now:
+                return f"Expired (on {expiry_dt.strftime('%Y-%m-%d')})"
+                
+            delta = expiry_dt - now
+            days = delta.days
+            hours = delta.seconds // 3600
+            
+            if days > 0:
+                return f"Active (Expires in {days}d {hours}h)"
+            else:
+                minutes = (delta.seconds % 3600) // 60
+                return f"Active (Expires in {hours}h {minutes}m)"
+        except Exception:
+            return f"Expires: {expires_at}"
+    except Exception:
+        pass
+    return "Unknown"
+
+def subscription_sync_loop():
+    try:
+        time.sleep(5)
+    except KeyboardInterrupt:
+        return
+    while True:
+        try:
+            pubkey = "Unknown"
+            if os.path.exists(CONFIG_PATH):
+                with open(CONFIG_PATH, 'r') as f:
+                    config_content = f.read()
+                private_key_match = re.search(r'PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE)
+                if private_key_match:
+                    try:
+                        proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
+                        pubkey = proc.stdout.decode().strip()
+                    except Exception:
+                        pass
+            
+            if pubkey and pubkey != "Unknown":
+                lazy_sync(pubkey)
+        except Exception as e:
+            print(f"Error in subscription sync loop: {e}", file=sys.stderr)
+        
+        try:
+            time.sleep(86400)
+        except KeyboardInterrupt:
+            break
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        if self.path == "/api/status":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            
+            status_data = get_status()
+            
+            pubkey = "Unknown"
+            if os.path.exists(CONFIG_PATH):
+                try:
+                    with open(CONFIG_PATH, 'r') as f:
+                        config_content = f.read()
+                    private_key_match = re.search(r'PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE)
+                    if private_key_match:
+                        proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
+                        pubkey = proc.stdout.decode().strip()
+                except Exception:
+                    pass
+            
+            expiry = "Unknown"
+            if os.path.exists(META_FILE_PATH):
+                try:
+                    with open(META_FILE_PATH, 'r') as f:
+                        meta = json.load(f)
+                        expiry = meta.get("expiresAt", "Unknown")
+                except Exception:
+                    pass
+                    
+            target_host, target_port = get_target_details()
+            
+            vpn_port = DEFAULT_VPN_PORT
+            public_ip = "Unknown"
+            if os.path.exists(CONFIG_PATH):
+                try:
+                    with open(CONFIG_PATH, 'r') as f:
+                        config_content = f.read()
+                    vpn_port = extract_vpn_port(config_content)
+                    endpoint_match = re.search(r'Endpoint\s*=\s*([^:\s]+):\d+', config_content, re.IGNORECASE)
+                    public_ip = endpoint_match.group(1) if endpoint_match else "Unknown"
+                except Exception:
+                    pass
+
+            wg_ip = get_wg_ip()
+            internal_octet = wg_ip.split('.')[-1] if wg_ip else "Unknown"
+
+            response = {
+                "enabled": is_enabled(),
+                "status": status_data["status"],
+                "vpn_connected": status_data["vpn_connected"],
+                "handshake": status_data["handshake"],
+                "pubkey": pubkey,
+                "expires_at": expiry,
+                "target_host": target_host,
+                "target_port": target_port,
+                "vpn_port": vpn_port,
+                "public_ip": public_ip,
+                "socks5_port": 1080,
+                "internal_octet": internal_octet
+            }
+            self.wfile.write(json.dumps(response).encode("utf-8"))
+            return
+
+        web_dir = os.path.join(os.path.dirname(__file__), "web")
+        target_path = self.path.lstrip("/")
+        if not target_path or target_path == "":
+            target_path = "index.html"
+            
+        safe_path = os.path.abspath(os.path.join(web_dir, target_path))
+        if not safe_path.startswith(os.path.abspath(web_dir)):
+            self.send_error(403, "Access denied")
+            return
+
+        if os.path.exists(safe_path) and os.path.isfile(safe_path):
+            self.send_response(200)
+            if safe_path.endswith(".html"):
+                self.send_header("Content-Type", "text/html")
+            elif safe_path.endswith(".css"):
+                self.send_header("Content-Type", "text/css")
+            elif safe_path.endswith(".js"):
+                self.send_header("Content-Type", "application/javascript")
+            elif safe_path.endswith(".svg"):
+                self.send_header("Content-Type", "image/svg+xml")
+            elif safe_path.endswith(".png"):
+                self.send_header("Content-Type", "image/png")
+            else:
+                self.send_header("Content-Type", "application/octet-stream")
+            self.end_headers()
+            
+            with open(safe_path, "rb") as f:
+                self.wfile.write(f.read())
+        else:
+            self.send_error(404, "File not found")
+
+def web_server_thread():
+    try:
+        server = ThreadingHTTPServer(("0.0.0.0", 80), DashboardHTTPRequestHandler)
+        print("Web UI Dashboard server running on port 80...")
+        server.serve_forever()
+    except Exception as e:
+        print(f"Failed to start web server on port 80: {e}", file=sys.stderr)
+        try:
+            server = ThreadingHTTPServer(("0.0.0.0", 8000), DashboardHTTPRequestHandler)
+            print("Web UI Dashboard server fallback running on port 8000...")
+            server.serve_forever()
+        except Exception as e2:
+            print(f"Failed to start fallback web server: {e2}", file=sys.stderr)
+
+def is_enabled():
+    try:
+        if os.path.exists(APP_CONFIG_PATH):
+            with open(APP_CONFIG_PATH, 'r') as f:
+                config_data = json.load(f)
+                return config_data.get("enabled", False)
+    except Exception as e:
+        print(f"Error checking enabled status: {e}", file=sys.stderr)
+    return False
 
 def extract_vpn_port(config_content):
     try:
@@ -261,6 +538,12 @@ def get_properties():
                     "value": str(vpn_port),
                     "description": "Your assigned port for inbound Lightning connections.",
                     "copyable": True
+                },
+                "Subscription Expiry": {
+                    "type": "string",
+                    "value": format_subscription_expiry(),
+                    "description": "Remaining validity of your TunnelSats subscription.",
+                    "copyable": False
                 }
             }
         }
@@ -289,6 +572,17 @@ def main():
         signal.signal(signal.SIGTERM, shutdown_handler)
         signal.signal(signal.SIGINT, shutdown_handler)
         try:
+            import threading
+            sync_thread = threading.Thread(target=subscription_sync_loop, daemon=True)
+            sync_thread.start()
+
+            web_thread = threading.Thread(target=web_server_thread, daemon=True)
+            web_thread.start()
+
+            if not is_enabled():
+                print("TunnelSats is disabled. Staying idle...", file=sys.stderr)
+                while True:
+                    time.sleep(1)
             if not os.path.exists(CONFIG_PATH):
                 print(f"WireGuard config not found at {CONFIG_PATH}. Waiting for user setup...", file=sys.stderr)
                 while not os.path.exists(CONFIG_PATH):
@@ -328,6 +622,10 @@ def main():
     elif command == "health":
         target = sys.argv[2] if len(sys.argv) > 2 else "vpn"
         
+        if not is_enabled():
+            print(json.dumps({"result": "ok"}))
+            sys.exit(0)
+            
         if target == "vpn":
             status = get_status()
             if status["vpn_connected"]:
@@ -353,6 +651,14 @@ def main():
         if subcommand == "get":
             # The UI requires the 'spec' metadata exactly as defined in config_spec.yaml
             spec = {
+                "enabled": {
+                    "type": "boolean",
+                    "name": "Enable TunnelSats",
+                    "description": "Turn the TunnelSats VPN tunnel On or Off.",
+                    "nullable": True,
+                    "default": False,
+                    "depends-on": {}
+                },
                 "target-node": {
                     "type": "enum",
                     "name": "Target Lightning Node",
@@ -362,20 +668,20 @@ def main():
                         "lnd": "LND (lnd.embassy)",
                         "cln": "Core Lightning (c-lightning.embassy)"
                     },
-                    "default": "lnd"
+                    "default": "lnd",
+                    "depends-on": {}
                 },
                 "tunnelsats-conf": {
                     "type": "string",
                     "name": "WireGuard Configuration",
                     "description": "Paste the content of your TunnelSats .conf file here. Ensure it includes the '# VPNPort: XXXXX' metadata comment for automatic port-forwarding.",
-                    "nullable": False,
+                    "nullable": True,
                     "default": None,
                     "placeholder": "[Interface]\nPrivateKey = <your_private_key>\nAddress = 10.x.x.x/32\n# VPNPort: 12345\n...\n",
-                    "pattern": ".*",
-                    "pattern-description": "Please paste a valid WireGuard configuration.",
                     "textarea": True,
                     "copyable": True,
-                    "masked": False
+                    "masked": False,
+                    "depends-on": {}
                 }
             }
             
@@ -385,27 +691,39 @@ def main():
                     config_data = json.load(f)
             else:
                 config_data = {
+                    "enabled": False,
                     "target-node": "lnd",
                     "tunnelsats-conf": ""
                 }
                 
             print(json.dumps({
                 "config": config_data,
-                "spec": spec
+                "spec": spec,
+                "depends-on": {}
             }))
                 
         elif subcommand == "set":
             # StartOS passes the UI values via stdin
             try:
-                config_data = json.load(sys.stdin)
+                raw_input = json.load(sys.stdin)
                 
-                # Validation checking malformed fields
-                wg_conf = config_data.get("tunnelsats-conf", "")
-                try:
-                    validate_config(wg_conf)
-                except ValueError as ve:
-                    print(f"Invalid WireGuard Configuration: {str(ve)}", file=sys.stderr)
-                    sys.exit(1)
+                # Handle both wrapped and unwrapped (for tests) formats
+                if isinstance(raw_input, dict) and "config" in raw_input:
+                    config_data = raw_input.get("config", {})
+                    depends_on = raw_input.get("depends-on", {})
+                else:
+                    config_data = raw_input
+                    depends_on = {}
+                
+                enabled = config_data.get("enabled", False)
+                wg_conf = config_data.get("tunnelsats-conf") or ""
+                
+                if enabled or wg_conf:
+                    try:
+                        validate_config(wg_conf)
+                    except ValueError as ve:
+                        print(f"Invalid WireGuard Configuration: {str(ve)}", file=sys.stderr)
+                        sys.exit(1)
                 
                 # 1. Save the JSON config for future "get" calls
                 with open(APP_CONFIG_PATH, 'w') as f:
@@ -415,10 +733,18 @@ def main():
                 if wg_conf:
                     with open(CONFIG_PATH, 'w') as f:
                         f.write(wg_conf)
+                elif os.path.exists(CONFIG_PATH):
+                    try:
+                        os.remove(CONFIG_PATH)
+                    except Exception:
+                        pass
                 
-                # StartOS expects the config back on success
-                print(json.dumps(config_data))
-                
+                # StartOS always expects the wrapped format with top-level depends-on
+                print(json.dumps({
+                    "config": config_data,
+                    "depends-on": {}
+                }))
+                    
             except Exception as e:
                 print(f"Error setting config: {str(e)}", file=sys.stderr)
                 sys.exit(1)

--- a/bridge.py
+++ b/bridge.py
@@ -232,12 +232,10 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             # Prevent unauthorized container-to-container scraping from within the same network
             client_ip = self.client_address[0]
             is_local = client_ip in ("127.0.0.1", "::1", "localhost")
+            has_proxy_headers = "x-forwarded-for" in self.headers or "x-forwarded-host" in self.headers
             
-            # Identify the unspoofable network gateway IP (the reverse proxy host gateway)
-            gateway_ip = get_default_gateway()
-            
-            # Enforce that remote connections must only originate from the host gateway
-            if not is_local and gateway_ip and client_ip != gateway_ip:
+            # Non-local requests must go through the StartOS HTTP reverse proxy
+            if not is_local and not has_proxy_headers:
                 self.send_error(403, "Access denied")
                 return
 
@@ -824,7 +822,11 @@ def main():
                 enabled = config_data.get("enabled", False)
                 wg_conf = config_data.get("tunnelsats-conf") or ""
                 
-                if enabled or wg_conf:
+                if enabled and not wg_conf:
+                    print("Invalid WireGuard Configuration: enabled tunnels require a WireGuard configuration", file=sys.stderr)
+                    sys.exit(1)
+                
+                if wg_conf:
                     try:
                         validate_config(wg_conf)
                     except ValueError as ve:
@@ -839,6 +841,12 @@ def main():
                 if wg_conf:
                     with open(CONFIG_PATH, 'w') as f:
                         f.write(wg_conf)
+                elif "tunnelsats-conf" in config_data and config_data["tunnelsats-conf"] == "":
+                    if os.path.exists(CONFIG_PATH):
+                        try:
+                            os.remove(CONFIG_PATH)
+                        except Exception:
+                            pass
                 
 
                 

--- a/bridge.py
+++ b/bridge.py
@@ -53,6 +53,20 @@ def atomic_write_json(filepath, data):
                 pass
         raise e
 
+def get_default_gateway():
+    try:
+        with open("/proc/net/route", "r") as f:
+            for line in f.read().splitlines()[1:]:
+                parts = line.split()
+                if len(parts) >= 3 and parts[1] == "00000000":
+                    hex_gw = parts[2]
+                    octets = [int(hex_gw[i:i+2], 16) for i in range(0, 8, 2)]
+                    octets.reverse()
+                    return ".".join(map(str, octets))
+    except Exception:
+        pass
+    return None
+
 def lazy_sync(wg_pubkey):
     if not wg_pubkey or wg_pubkey == "Unknown" or wg_pubkey == "Not available":
         return
@@ -218,15 +232,22 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             # Prevent unauthorized container-to-container scraping from within the same network
             client_ip = self.client_address[0]
             is_local = client_ip in ("127.0.0.1", "::1", "localhost")
-            host_header = self.headers.get("Host", "").lower()
             
+            # Identify the unspoofable network gateway IP (the reverse proxy host gateway)
+            gateway_ip = get_default_gateway()
+            
+            # Enforce that remote connections must only originate from the host gateway
+            if not is_local and gateway_ip and client_ip != gateway_ip:
+                self.send_error(403, "Access denied")
+                return
+
+            host_header = self.headers.get("Host", "").lower()
             if is_local:
                 allowed_suffixes = ("localhost", "127.0.0.1", "[::1]")
             else:
                 allowed_suffixes = (".local", ".lan", ".onion")
                 
             is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
-            
             if not is_allowed_host:
                 self.send_error(403, "Access denied")
                 return

--- a/bridge.py
+++ b/bridge.py
@@ -57,21 +57,30 @@ def lazy_sync(wg_pubkey):
             except Exception:
                 pass
 
-        with urllib.request.urlopen(req, timeout=10) as response:
-            if response.status == 200:
-                res_data = json.loads(response.read().decode("utf-8"))
-                if isinstance(res_data, dict):
-                    expiry = res_data.get("expiry")
-                    if expiry:
-                        meta["expiresAt"] = expiry
-                    
-                    server_domain = res_data.get("server_domain")
-                    if server_domain:
-                        meta["serverDomain"] = server_domain
-                    
-                    vpn_port = res_data.get("vpn_port")
-                    if vpn_port:
-                        meta["vpnPort"] = vpn_port
+        response_data = None
+        for attempt in range(5):
+            try:
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    if response.status == 200:
+                        response_data = json.loads(response.read().decode("utf-8"))
+                        break
+            except Exception as e:
+                if attempt == 4:
+                    raise e
+                time.sleep(5)
+
+        if response_data and isinstance(response_data, dict):
+            expiry = response_data.get("expiry")
+            if expiry:
+                meta["expiresAt"] = expiry
+            
+            server_domain = response_data.get("server_domain")
+            if server_domain:
+                meta["serverDomain"] = server_domain
+            
+            vpn_port = response_data.get("vpn_port")
+            if vpn_port:
+                meta["vpnPort"] = vpn_port
 
         # Fallback to comments parsing if config file exists and we don't have expiresAt
         if not meta.get("expiresAt") and os.path.exists(CONFIG_PATH):
@@ -175,7 +184,8 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
         pass
 
     def do_GET(self):
-        if self.path == "/api/status":
+        path_only = self.path.partition('?')[0].partition('#')[0]
+        if path_only == "/api/status":
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
@@ -187,7 +197,7 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
                 try:
                     with open(CONFIG_PATH, 'r') as f:
                         config_content = f.read()
-                    private_key_match = re.search(r'PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE)
+                    private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
                     if private_key_match:
                         proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
                         pubkey = proc.stdout.decode().strip()
@@ -212,7 +222,7 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
                     with open(CONFIG_PATH, 'r') as f:
                         config_content = f.read()
                     vpn_port = extract_vpn_port(config_content)
-                    endpoint_match = re.search(r'Endpoint\s*=\s*([^:\s]+):\d+', config_content, re.IGNORECASE)
+                    endpoint_match = re.search(r'^\s*(?!#|;)\s*Endpoint\s*=\s*([^:\s]+):\d+', config_content, re.IGNORECASE | re.MULTILINE)
                     public_ip = endpoint_match.group(1) if endpoint_match else "Unknown"
                 except Exception:
                     pass
@@ -238,12 +248,12 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             return
 
         web_dir = os.path.join(os.path.dirname(__file__), "web")
-        target_path = self.path.lstrip("/")
+        target_path = path_only.lstrip("/")
         if not target_path or target_path == "":
             target_path = "index.html"
             
         safe_path = os.path.abspath(os.path.join(web_dir, target_path))
-        if not safe_path.startswith(os.path.abspath(web_dir)):
+        if os.path.commonpath([web_dir, safe_path]) != os.path.abspath(web_dir):
             self.send_error(403, "Access denied")
             return
 
@@ -490,10 +500,10 @@ def get_properties():
             
         vpn_port = extract_vpn_port(config_content)
         
-        endpoint_match = re.search(r'Endpoint\s*=\s*([^:\s]+):\d+', config_content, re.IGNORECASE)
+        endpoint_match = re.search(r'^\s*(?!#|;)\s*Endpoint\s*=\s*([^:\s]+):\d+', config_content, re.IGNORECASE | re.MULTILINE)
         public_ip = endpoint_match.group(1) if endpoint_match else "Unknown"
         
-        private_key_match = re.search(r'PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE)
+        private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
         pubkey = "Unknown"
         if private_key_match:
             try:

--- a/bridge.py
+++ b/bridge.py
@@ -29,6 +29,30 @@ def parse_config_comments(config_content):
             meta["vpnPort"] = int(match.group(1))
     return meta
 
+def is_valid_iso_expiry(expiry_str):
+    if not expiry_str:
+        return False
+    try:
+        # ISO format like "2026-10-02T21:18:07.000Z"
+        datetime.fromisoformat(expiry_str.replace("Z", "+00:00"))
+        return True
+    except Exception:
+        return False
+
+def atomic_write_json(filepath, data):
+    tmp_path = filepath + ".tmp"
+    try:
+        with open(tmp_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp_path, filepath)
+    except Exception as e:
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass
+        raise e
+
 def lazy_sync(wg_pubkey):
     if not wg_pubkey or wg_pubkey == "Unknown" or wg_pubkey == "Not available":
         return
@@ -48,30 +72,34 @@ def lazy_sync(wg_pubkey):
     )
     
     meta = {}
+    loaded_existing = False
     try:
         # Load existing metadata if it exists
         if os.path.exists(META_FILE_PATH):
             try:
                 with open(META_FILE_PATH, 'r') as f:
                     meta = json.load(f)
+                    loaded_existing = True
             except Exception:
                 pass
 
         response_data = None
+        api_success = False
         for attempt in range(5):
             try:
                 with urllib.request.urlopen(req, timeout=10) as response:
                     if response.status == 200:
                         response_data = json.loads(response.read().decode("utf-8"))
+                        api_success = True
                         break
             except Exception as e:
                 if attempt == 4:
                     raise e
                 time.sleep(5)
 
-        if response_data and isinstance(response_data, dict):
+        if api_success and response_data and isinstance(response_data, dict):
             expiry = response_data.get("expiry")
-            if expiry:
+            if expiry and is_valid_iso_expiry(expiry):
                 meta["expiresAt"] = expiry
             
             server_domain = response_data.get("server_domain")
@@ -88,14 +116,15 @@ def lazy_sync(wg_pubkey):
                 with open(CONFIG_PATH, 'r') as f:
                     config_content = f.read()
                 parsed = parse_config_comments(config_content)
-                if parsed.get("expiresAt"):
-                    meta["expiresAt"] = parsed["expiresAt"]
+                expiry = parsed.get("expiresAt")
+                if expiry and is_valid_iso_expiry(expiry):
+                    meta["expiresAt"] = expiry
             except Exception:
                 pass
 
-        # Write metadata back
-        with open(META_FILE_PATH, 'w') as f:
-            json.dump(meta, f, indent=2)
+        # Write metadata back atomically if we successfully loaded/updated something
+        if meta or not loaded_existing:
+            atomic_write_json(META_FILE_PATH, meta)
             
     except Exception as e:
         print(f"Error during lazy subscription sync: {e}", file=sys.stderr)
@@ -106,10 +135,10 @@ def lazy_sync(wg_pubkey):
                 with open(CONFIG_PATH, 'r') as f:
                     config_content = f.read()
                 parsed = parse_config_comments(config_content)
-                if parsed.get("expiresAt"):
-                    meta["expiresAt"] = parsed["expiresAt"]
-                    with open(META_FILE_PATH, 'w') as f:
-                        json.dump(meta, f, indent=2)
+                expiry = parsed.get("expiresAt")
+                if expiry and is_valid_iso_expiry(expiry):
+                    meta["expiresAt"] = expiry
+                    atomic_write_json(META_FILE_PATH, meta)
             except Exception:
                 pass
 
@@ -159,7 +188,7 @@ def subscription_sync_loop():
             if os.path.exists(CONFIG_PATH):
                 with open(CONFIG_PATH, 'r') as f:
                     config_content = f.read()
-                private_key_match = re.search(r'PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE)
+                private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
                 if private_key_match:
                     try:
                         proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)

--- a/bridge.py
+++ b/bridge.py
@@ -219,10 +219,15 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             client_ip = self.client_address[0]
             is_local = client_ip in ("127.0.0.1", "::1", "localhost")
             host_header = self.headers.get("Host", "").lower()
-            allowed_suffixes = (".local", ".lan", ".onion", "localhost", "127.0.0.1", "[::1]")
+            
+            if is_local:
+                allowed_suffixes = ("localhost", "127.0.0.1", "[::1]")
+            else:
+                allowed_suffixes = (".local", ".lan", ".onion")
+                
             is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
             
-            if not is_local and not is_allowed_host:
+            if not is_allowed_host:
                 self.send_error(403, "Access denied")
                 return
 

--- a/bridge.py
+++ b/bridge.py
@@ -263,13 +263,19 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
             # Identify the network gateway IP
             gateway_ip = get_default_gateway()
             
-            # Enforce that remote connections must only originate from the same /24 subnet as the gateway
-            is_trusted_proxy = False
-            if gateway_ip:
-                g_parts = gateway_ip.split('.')
-                c_parts = client_ip.split('.')
-                if len(g_parts) >= 3 and len(c_parts) >= 3:
-                    is_trusted_proxy = (g_parts[0] == c_parts[0] and g_parts[1] == c_parts[1] and g_parts[2] == c_parts[2])
+            # Resolve the StartOS host/proxy IP
+            embassy_ip = None
+            try:
+                import socket
+                embassy_ip = socket.gethostbyname("embassy")
+            except Exception:
+                pass
+                
+            # Enforce that remote connections must strictly originate from the host gateway or the embassy proxy IP
+            is_trusted_proxy = (
+                (gateway_ip and client_ip == gateway_ip) or
+                (embassy_ip and client_ip == embassy_ip)
+            )
             
             if not is_local and not is_trusted_proxy:
                 self.send_error(403, "Access denied")

--- a/bridge.py
+++ b/bridge.py
@@ -849,7 +849,7 @@ def main():
                 if wg_conf:
                     with open(CONFIG_PATH, 'w') as f:
                         f.write(wg_conf)
-                elif "tunnelsats-conf" in config_data and config_data["tunnelsats-conf"] == "":
+                elif "tunnelsats-conf" in config_data and config_data["tunnelsats-conf"] in ("", None):
                     if os.path.exists(CONFIG_PATH):
                         try:
                             os.remove(CONFIG_PATH)

--- a/bridge.py
+++ b/bridge.py
@@ -468,6 +468,12 @@ def vpn_down(config_path):
             wireproxy_process.kill()
         wireproxy_process = None
         print("wireproxy stopped.")
+    
+    # Fallback to pkill to clean up any orphaned wireproxy processes
+    try:
+        subprocess.run(["pkill", "-f", "wireproxy"])
+    except Exception:
+        pass
 
 def is_wireproxy_running():
     try:
@@ -628,8 +634,11 @@ def main():
 
             if not is_enabled():
                 print("TunnelSats is disabled. Staying idle...", file=sys.stderr)
-                while True:
+                while not is_enabled():
                     time.sleep(1)
+                print("TunnelSats has been enabled. Reloading service...", file=sys.stderr)
+                sys.exit(0)
+
             if not os.path.exists(CONFIG_PATH):
                 print(f"WireGuard config not found at {CONFIG_PATH}. Waiting for user setup...", file=sys.stderr)
                 while not os.path.exists(CONFIG_PATH):
@@ -645,6 +654,14 @@ def main():
             
             # Stay alive and monitor the wireproxy process
             while True:
+                if not is_enabled():
+                    print("TunnelSats has been disabled. Stopping VPN and entering idle state...", file=sys.stderr)
+                    vpn_down(CONFIG_PATH)
+                    while not is_enabled():
+                        time.sleep(1)
+                    print("TunnelSats has been re-enabled. Reloading service...", file=sys.stderr)
+                    sys.exit(0)
+
                 if wireproxy_process and wireproxy_process.poll() is not None:
                     print("wireproxy process exited unexpectedly.", file=sys.stderr)
                     sys.exit(1)
@@ -797,12 +814,7 @@ def main():
                     with open(CONFIG_PATH, 'w') as f:
                         f.write(wg_conf)
                 
-                # 3. If disabled, terminate any running wireproxy process to force container reload
-                if not enabled:
-                    try:
-                        subprocess.run(["pkill", "-f", "wireproxy"])
-                    except Exception:
-                        pass
+
                 
                 # StartOS always expects the wrapped format with top-level depends-on
                 print(json.dumps({

--- a/bridge.py
+++ b/bridge.py
@@ -215,6 +215,12 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         path_only = self.path.partition('?')[0].partition('#')[0]
         if path_only == "/api/status":
+            # Prevent unauthorized container-to-container scraping from within the same Podman network
+            host_header = self.headers.get("Host", "")
+            if "tunnelsats.embassy" in host_header.lower():
+                self.send_error(403, "Access denied")
+                return
+
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
@@ -320,7 +326,11 @@ def is_enabled():
         if os.path.exists(APP_CONFIG_PATH):
             with open(APP_CONFIG_PATH, 'r') as f:
                 config_data = json.load(f)
-                return config_data.get("enabled", False)
+                if "enabled" in config_data:
+                    return config_data["enabled"]
+        # Default to True if a v3 config exists (upgrade path/existing configurations)
+        if os.path.exists(CONFIG_PATH):
+            return True
     except Exception as e:
         print(f"Error checking enabled status: {e}", file=sys.stderr)
     return False
@@ -655,8 +665,24 @@ def main():
         target = sys.argv[2] if len(sys.argv) > 2 else "vpn"
         
         if not is_enabled():
-            print(json.dumps({"result": "ok"}))
-            sys.exit(0)
+            if target == "vpn":
+                if not is_wireproxy_running():
+                    print(json.dumps({"result": "ok"}))
+                    sys.exit(0)
+                else:
+                    print(json.dumps({"result": "VPN is running but should be stopped"}))
+                    sys.exit(1)
+            elif target == "proxy":
+                status = check_proxy_health()
+                if not status["proxy_ready"]:
+                    print(json.dumps({"result": "ok"}))
+                    sys.exit(0)
+                else:
+                    print(json.dumps({"result": "Proxy is active but should be stopped"}))
+                    sys.exit(1)
+            else:
+                print(json.dumps({"result": "ok"}))
+                sys.exit(0)
             
         if target == "vpn":
             status = get_status()
@@ -765,9 +791,11 @@ def main():
                 if wg_conf:
                     with open(CONFIG_PATH, 'w') as f:
                         f.write(wg_conf)
-                elif os.path.exists(CONFIG_PATH):
+                
+                # 3. If disabled, terminate any running wireproxy process to force container reload
+                if not enabled:
                     try:
-                        os.remove(CONFIG_PATH)
+                        subprocess.run(["pkill", "-f", "wireproxy"])
                     except Exception:
                         pass
                 

--- a/bridge.py
+++ b/bridge.py
@@ -389,7 +389,8 @@ def is_enabled():
                     with open(APP_CONFIG_PATH, 'r') as f:
                         config_data = json.load(f)
                     if "enabled" in config_data:
-                        _enabled_cache = config_data["enabled"]
+                        val = config_data["enabled"]
+                        _enabled_cache = val if val is not None else False
                     else:
                         _enabled_cache = None
                     _enabled_cache_mtime = mtime

--- a/bridge.py
+++ b/bridge.py
@@ -81,7 +81,8 @@ def get_wg_pubkey():
             private_key_match = re.search(r'^\s*(?!#|;)\s*PrivateKey\s*=\s*(.+)', config_content, re.IGNORECASE | re.MULTILINE)
             if private_key_match:
                 proc = subprocess.run(["wg", "pubkey"], input=private_key_match.group(1).strip().encode(), capture_output=True)
-                return proc.stdout.decode().strip()
+                if proc.returncode == 0:
+                    return proc.stdout.decode().strip()
         except Exception:
             pass
     return "Unknown"
@@ -287,17 +288,23 @@ class DashboardHTTPRequestHandler(BaseHTTPRequestHandler):
                 return
 
             host_header = self.headers.get("Host", "").lower()
+            if host_header.startswith('['):
+                host_name = host_header.partition(']')[0] + ']'
+            else:
+                host_name = host_header.partition(':')[0]
+
             if is_local:
-                allowed_suffixes = ("localhost", "127.0.0.1", "[::1]")
-                is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
+                is_allowed_host = host_name in ("localhost", "127.0.0.1", "[::1]")
             else:
                 allowed_suffixes = (".local", ".lan", ".onion")
-                is_allowed_host = any(host_header.endswith(suffix) or f"{suffix}:" in host_header for suffix in allowed_suffixes)
+                is_allowed_host = any(host_name.endswith(suffix) for suffix in allowed_suffixes)
                 if not is_allowed_host:
-                    host_name = host_header.partition(':')[0]
+                    ip_str = host_name
+                    if ip_str.startswith('[') and ip_str.endswith(']'):
+                        ip_str = ip_str[1:-1]
                     import ipaddress
                     try:
-                        is_allowed_host = ipaddress.ip_address(host_name).is_private
+                        is_allowed_host = ipaddress.ip_address(ip_str).is_private
                     except ValueError:
                         pass
             

--- a/config_spec.yaml
+++ b/config_spec.yaml
@@ -1,3 +1,9 @@
+enabled:
+  type: boolean
+  name: "Enable TunnelSats"
+  description: "Turn the TunnelSats VPN tunnel On or Off."
+  nullable: true
+  default: false
 target-node:
   type: enum
   name: "Target Lightning Node"
@@ -13,15 +19,13 @@ tunnelsats-conf:
   type: string
   name: "WireGuard Configuration"
   description: "Paste the content of your TunnelSats .conf file here. Ensure it includes the '# VPNPort: XXXXX' metadata comment for automatic port-forwarding."
-  nullable: false
+  nullable: true
   placeholder: |
     [Interface]
     PrivateKey = <your_private_key>
     Address = 10.x.x.x/32
     # VPNPort: 12345
     ...
-  pattern: ".*"
-  pattern-description: "Please paste a valid WireGuard configuration."
   textarea: true
   copyable: true
   masked: false

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,6 +1,6 @@
 id: tunnelsats
 title: "TunnelSats"
-version: 0.1.0
+version: 0.2.0
 release-notes: "Initial release for StartOS."
 license: "MIT"
 wrapper-repo: "https://github.com/Tunnelsats/tunnelsats-startos"
@@ -9,8 +9,8 @@ support-site: "https://github.com/Tunnelsats/tunnelsats/issues"
 marketing-site: "https://tunnelsats.com"
 min-os-version: "0.3.5"
 description:
-  short: "A privacy-focused VPN gateway for Lightning Nodes."
-  long: "TunnelSats provides premium VPN infrastructure for Lightning Nodes (LND/CLN), enabling clearnet inbound connections and masking outbound traffic to improve routing performance and privacy."
+  short: "A privacy-focused VPN gateway for Lightning Nodes (LND/CLN)."
+  long: "TunnelSats provides premium VPN infrastructure specifically for Lightning Nodes (LND/CLN), enabling clearnet inbound connections and masking outbound peer-to-peer traffic. Please note: TunnelSats is a dedicated Lightning Network VPN, NOT a general VPN for all StartOS system or server traffic."
 assets:
   license: LICENSE
   icon: icon.svg
@@ -80,6 +80,20 @@ interfaces:
       - tcp
       - http
       - socks5
+  ui:
+    name: "Web Dashboard"
+    description: "TunnelSats Web Dashboard, connection properties, and setup instructions."
+    tor-config:
+      port-mapping:
+        80: "80"
+    lan-config:
+      443:
+        ssl: true
+        internal: 80
+    ui: true
+    protocols:
+      - tcp
+      - http
 backup:
   create:
     type: docker

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,7 +1,7 @@
 id: tunnelsats
 title: "TunnelSats"
 version: 0.2.0
-release-notes: "Initial release for StartOS."
+release-notes: "v0.2.0: Adds web dashboard UI with subscription expiry tracking, enable/disable tunnel toggle, and automatic port-forwarding configuration."
 license: "MIT"
 wrapper-repo: "https://github.com/Tunnelsats/tunnelsats-startos"
 upstream-repo: "https://github.com/Tunnelsats/tunnelsats"

--- a/scripts/check_spec.py
+++ b/scripts/check_spec.py
@@ -1,0 +1,49 @@
+import json
+import subprocess
+import os
+import sys
+
+# Simulate the inner spec only
+spec = {
+    "target-node": {
+        "type": "enum",
+        "name": "Target Lightning Node",
+        "description": "Select which Lightning service on your StartOS server will receive inbound connections.",
+        "values": ["lnd", "cln"],
+        "valueNames": {
+            "lnd": "LND (lnd.embassy)",
+            "cln": "Core Lightning (c-lightning.embassy)"
+        },
+        "default": "lnd",
+        "depends-on": {}, # Testing this
+        "help-md": None,
+        "warning": None
+    },
+    "tunnelsats-conf": {
+        "type": "string",
+        "display-as": "textarea",
+        "name": "WireGuard Configuration",
+        "description": "Paste the content of your TunnelSats .conf file here.",
+        "nullable": False,
+        "placeholder": "[Interface]...",
+        "depends-on": {}, # Testing this
+        "pattern": ".*",
+        "pattern-description": "Invalid config.",
+        "help-md": None,
+        "warning": None
+    }
+}
+
+with open("test_spec.json", "w") as f:
+    json.dump(spec, f, indent=4)
+
+print("Running start-sdk verify config-spec test_spec.json...")
+result = subprocess.run(["start-sdk", "verify", "config-spec", "test_spec.json"], capture_output=True, text=True)
+
+print("STDOUT:", result.stdout)
+print("STDERR:", result.stderr)
+
+if result.returncode == 0:
+    print("\n[SUCCESS] Spec is valid!")
+else:
+    print("\n[FAIL] Spec is invalid!")

--- a/scripts/remote_config_test.sh
+++ b/scripts/remote_config_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+
+# Load master password from git-ignored .env.local
+ENV_FILE=".env.local"
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: $ENV_FILE not found."
+    exit 1
+fi
+
+# Extract safely ignoring stray trailing quotes (sync with deploy-sideload.sh)
+MASTER_PWD=$(grep '^startOS-Master-pwd=' "$ENV_FILE" | cut -d '=' -f 2- | tr -d '"' | tr -d "'" | tr -d '\r\n')
+HOST="https://public-fallacy.local"
+SDK_CLI="/home/hakuna/.cargo/bin/start-cli"
+
+if [ -z "$MASTER_PWD" ]; then
+    echo "Error: password not found"
+    exit 1
+fi
+
+echo "Phase 1: Authenticating to $HOST..."
+$SDK_CLI -h "$HOST" auth login "$MASTER_PWD"
+
+echo "Phase 2: Preparing and Pushing Configuration..."
+# Prepare the JSON-config
+CONF_CONTENT=$(cat tunnelsats-test.conf)
+# Escaping for JSON
+JSON_CONF=$(jq -n --arg conf "$CONF_CONTENT" '{"target-node": "lnd", "tunnelsats-conf": $conf}')
+
+# Push the config
+echo "Pushing tunnelsats configuration..."
+echo "$JSON_CONF" | $SDK_CLI -h "$HOST" package config tunnelsats set
+
+echo "Phase 3: Verifying Remote Logs..."
+# Wait a few seconds for service to restart and logs to populate
+sleep 5
+echo "Fetching tunnelsats logs..."
+$SDK_CLI -h "$HOST" package logs tunnelsats --limit 50

--- a/scripts/remote_config_test.sh
+++ b/scripts/remote_config_test.sh
@@ -1,38 +1,46 @@
 #!/usr/bin/env bash
+# remote_config_test.sh - Push a WireGuard config to a live StartOS node and verify logs.
+#
+# Usage:
+#   HOST=https://my-node.local SDK_CLI=/path/to/start-cli ./scripts/remote_config_test.sh
+#
+# Environment variables (can also be set in .env.local):
+#   HOST          - StartOS host URL (default: https://public-fallacy.local)
+#   SDK_CLI       - Path to start-cli binary (default: uses start-cli from PATH)
+#   MASTER_PWD    - StartOS master password (read from .env.local if not set)
 set -e
 
-# Load master password from git-ignored .env.local
-ENV_FILE=".env.local"
-if [ ! -f "$ENV_FILE" ]; then
-    echo "Error: $ENV_FILE not found."
-    exit 1
+# Load master password from git-ignored .env.local if MASTER_PWD not set
+if [ -z "$MASTER_PWD" ]; then
+    ENV_FILE=".env.local"
+    if [ ! -f "$ENV_FILE" ]; then
+        echo "Error: \$MASTER_PWD not set and $ENV_FILE not found."
+        exit 1
+    fi
+    # Extract safely ignoring stray trailing quotes
+    MASTER_PWD=$(grep '^startOS-Master-pwd=' "$ENV_FILE" | cut -d '=' -f 2- | tr -d '"' | tr -d "'" | tr -d '\r\n')
 fi
 
-# Extract safely ignoring stray trailing quotes (sync with deploy-sideload.sh)
-MASTER_PWD=$(grep '^startOS-Master-pwd=' "$ENV_FILE" | cut -d '=' -f 2- | tr -d '"' | tr -d "'" | tr -d '\r\n')
-HOST="https://public-fallacy.local"
-SDK_CLI="/home/hakuna/.cargo/bin/start-cli"
+# Resolve defaults from environment or fallback
+HOST="${HOST:-https://start9.local}"
+SDK_CLI="${SDK_CLI:-$(command -v start-cli 2>/dev/null || echo '/home/hakuna/.cargo/bin/start-cli')}"
 
 if [ -z "$MASTER_PWD" ]; then
-    echo "Error: password not found"
+    echo "Error: password not found in \$MASTER_PWD or .env.local"
     exit 1
 fi
 
 echo "Phase 1: Authenticating to $HOST..."
-$SDK_CLI -h "$HOST" auth login "$MASTER_PWD"
+"$SDK_CLI" -h "$HOST" auth login "$MASTER_PWD"
 
 echo "Phase 2: Preparing and Pushing Configuration..."
-# Prepare the JSON-config
 CONF_CONTENT=$(cat tunnelsats-test.conf)
-# Escaping for JSON
 JSON_CONF=$(jq -n --arg conf "$CONF_CONTENT" '{"target-node": "lnd", "tunnelsats-conf": $conf}')
 
-# Push the config
 echo "Pushing tunnelsats configuration..."
-echo "$JSON_CONF" | $SDK_CLI -h "$HOST" package config tunnelsats set
+echo "$JSON_CONF" | "$SDK_CLI" -h "$HOST" package config tunnelsats set
 
 echo "Phase 3: Verifying Remote Logs..."
-# Wait a few seconds for service to restart and logs to populate
 sleep 5
 echo "Fetching tunnelsats logs..."
-$SDK_CLI -h "$HOST" package logs tunnelsats --limit 50
+"$SDK_CLI" -h "$HOST" package logs tunnelsats --limit 50

--- a/scripts/test_config_schema.py
+++ b/scripts/test_config_schema.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import os
+import sys
+
+def run_command(cmd, input_str=None):
+    try:
+        result = subprocess.run(
+            cmd,
+            input=input_str,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        print(f"Error running command: {cmd}\nStderr: {e.stderr}", file=sys.stderr)
+        raise
+
+def main():
+    bridge_path = "./bridge.py"
+    sdk_verify_bin = "/home/hakuna/.cargo/bin/start-sdk"
+
+    print("Phase 1: Validating 'config get' Schema with StartOS SDK...")
+    try:
+        # 1. Fetch JSON from bridge.py
+        get_output = run_command(["python3", bridge_path, "config", "get"])
+        payload = json.loads(get_output)
+        
+        # 2. Extract only the 'spec' part as required by the SDK verify tool
+        spec_dict = payload['spec']
+        for field in spec_dict:
+            # We now require depends-on to be a dictionary {} or list [] for strictness
+            if "depends-on" not in spec_dict[field]:
+                print(f"[FAIL] Missing 'depends-on' field in spec for {field}")
+                sys.exit(1)
+            
+            if not isinstance(spec_dict[field]["depends-on"], (dict, list)):
+                print(f"[FAIL] 'depends-on' is not a dictionary or list in spec for {field}")
+                sys.exit(1)
+
+        spec_json = json.dumps(spec_dict)
+        spec_path = "/tmp/test_spec.json"
+        with open(spec_path, 'w') as f:
+            f.write(spec_json)
+
+        # 3. Use official SDK validator
+        run_command([sdk_verify_bin, "verify", "config-spec", spec_path])
+        print("[OK] JSON Schema is compliant with StartOS 0.3.5.x")
+
+    except Exception as e:
+        print(f"[FAIL] Schema Validation Failure: {e}")
+        sys.exit(1)
+
+    print("\nPhase 2: Testing 'config set' Validation Logic...")
+    
+    # Define test cases for config set validation
+    test_cases = [
+        {
+            "name": "Valid Config (Standard)",
+            "config": {
+                "target-node": "lnd",
+                "tunnelsats-conf": "[Interface]\nPrivateKey = pk1\nAddress = 10.0.0.1/32\n# VPNPort: 12345\n[Peer]\nEndpoint = 1.1.1.1:51820"
+            },
+            "should_pass": True
+        },
+        {
+            "name": "Valid Config (Alternative Port Tag)",
+            "config": {
+                "target-node": "cln",
+                "tunnelsats-conf": "[Interface]\nPrivateKey = pk2\nAddress = 10.0.0.2/32\n# Port Forwarding: 54321\n[Peer]\nEndpoint = 2.2.2.2:51820"
+            },
+            "should_pass": True
+        },
+        {
+            "name": "Invalid Config (Missing Port Tag)",
+            "config": {
+                "target-node": "lnd",
+                "tunnelsats-conf": "[Interface]\nPrivateKey = pk3\nAddress = 10.0.0.3/32\n[Peer]\nEndpoint = 3.3.3.3:51820"
+            },
+            "should_pass": False
+        },
+        {
+            "name": "Invalid Config (Missing PrivateKey)",
+            "config": {
+                "target-node": "lnd",
+                "tunnelsats-conf": "[Interface]\nAddress = 10.0.0.4/32\n# VPNPort: 11111\n[Peer]\nEndpoint = 4.4.4.4:51820"
+            },
+            "should_pass": False
+        }
+    ]
+
+    # Pre-setup mock data dir
+    os.makedirs("/tmp/data", exist_ok=True)
+    os.environ["DATA_DIR"] = "/tmp/data" # Ensure bridge.py uses /tmp/data for tests
+
+    for tc in test_cases:
+        print(f"Testing Case: {tc['name']}...", end=" ")
+        input_json = json.dumps({"config": tc['config'], "depends-on": {}})
+        try:
+            cmd = ["python3", bridge_path, "config", "set"]
+            output = run_command(cmd, input_str=input_json)
+            # Verify response includes depends-on
+            resp = json.loads(output)
+            assert "depends-on" in resp, f"Response missing 'depends-on': {resp}"
+            if tc['should_pass']:
+                print("[OK] Passed as expected")
+            else:
+                print("[FAIL] Accepted invalid config!")
+                sys.exit(1)
+        except subprocess.CalledProcessError:
+            if not tc['should_pass']:
+                print("[OK] Rejected as expected")
+            else:
+                print("[FAIL] Rejected valid config!")
+                sys.exit(1)
+
+    print("\nAll Tests Passed Successfully! Deployment is safe.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_config_schema.py
+++ b/scripts/test_config_schema.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import os
 import sys
+import shutil
 
 def run_command(cmd, input_str=None):
     try:
@@ -20,7 +21,11 @@ def run_command(cmd, input_str=None):
 
 def main():
     bridge_path = "./bridge.py"
-    sdk_verify_bin = "/home/hakuna/.cargo/bin/start-sdk"
+    # Allow override via START_SDK env var; fall back to PATH lookup then common cargo install location
+    sdk_verify_bin = os.environ.get(
+        "START_SDK",
+        shutil.which("start-sdk") or os.path.expanduser("~/.cargo/bin/start-sdk")
+    )
 
     print("Phase 1: Validating 'config get' Schema with StartOS SDK...")
     try:

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -56,6 +56,27 @@ class TestHTTPHandler(unittest.TestCase):
         handler.send_error.assert_not_called()
         handler.send_response.assert_called_with(200)
         
+        # Test local address with port and IPv6 formats
+        for host in ["localhost:8080", "[::1]", "[::1]:8080", "127.0.0.1:8080"]:
+            req_host = MagicMock()
+            req_host.client_address = ("127.0.0.1", 12345)
+            req_host.path = "/api/status"
+            req_host.headers = DummyHeaders({"Host": host})
+            wfile_host = BytesIO()
+            handler_host = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+            handler_host.client_address = req_host.client_address
+            handler_host.path = req_host.path
+            handler_host.headers = req_host.headers
+            handler_host.wfile = wfile_host
+            handler_host.send_response = MagicMock()
+            handler_host.send_header = MagicMock()
+            handler_host.end_headers = MagicMock()
+            handler_host.send_error = MagicMock()
+            
+            bridge.DashboardHTTPRequestHandler.do_GET(handler_host)
+            handler_host.send_error.assert_not_called()
+            handler_host.send_response.assert_called_with(200)
+        
         # Test untrusted subnet peer container: returns 403
         wfile_untrusted = BytesIO()
         handler_untrusted = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
@@ -114,6 +135,45 @@ class TestHTTPHandler(unittest.TestCase):
         bridge.DashboardHTTPRequestHandler.do_GET(handler_ip)
         handler_ip.send_error.assert_not_called()
         handler_ip.send_response.assert_called_with(200)
+
+        # Test trusted embassy proxy IP (with RFC 4193 private IPv6 Host): returns 200
+        wfile_ipv6_private = BytesIO()
+        handler_ipv6_private = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+        handler_ipv6_private.client_address = ("172.18.0.1", 12345)
+        handler_ipv6_private.path = "/api/status"
+        handler_ipv6_private.headers = DummyHeaders({
+            "Host": "[fd00::1]:8443",
+            "X-Forwarded-For": "1.2.3.4",
+            "X-Forwarded-Host": "fd00::1"
+        })
+        handler_ipv6_private.wfile = wfile_ipv6_private
+        handler_ipv6_private.send_response = MagicMock()
+        handler_ipv6_private.send_header = MagicMock()
+        handler_ipv6_private.end_headers = MagicMock()
+        handler_ipv6_private.send_error = MagicMock()
+        
+        bridge.DashboardHTTPRequestHandler.do_GET(handler_ipv6_private)
+        handler_ipv6_private.send_error.assert_not_called()
+        handler_ipv6_private.send_response.assert_called_with(200)
+
+        # Test trusted embassy proxy IP (with invalid public IPv6 Host): returns 403
+        wfile_ipv6_public = BytesIO()
+        handler_ipv6_public = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+        handler_ipv6_public.client_address = ("172.18.0.1", 12345)
+        handler_ipv6_public.path = "/api/status"
+        handler_ipv6_public.headers = DummyHeaders({
+            "Host": "[2001:4860:4860::8888]",
+            "X-Forwarded-For": "1.2.3.4",
+            "X-Forwarded-Host": "2001:4860:4860::8888"
+        })
+        handler_ipv6_public.wfile = wfile_ipv6_public
+        handler_ipv6_public.send_response = MagicMock()
+        handler_ipv6_public.send_header = MagicMock()
+        handler_ipv6_public.end_headers = MagicMock()
+        handler_ipv6_public.send_error = MagicMock()
+        
+        bridge.DashboardHTTPRequestHandler.do_GET(handler_ipv6_public)
+        handler_ipv6_public.send_error.assert_called_with(403, "Access denied")
 
         # Test trusted embassy proxy IP (with invalid public IP Host): returns 403
         wfile_pub_ip = BytesIO()

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -75,7 +75,7 @@ class TestHTTPHandler(unittest.TestCase):
         bridge.DashboardHTTPRequestHandler.do_GET(handler_untrusted)
         handler_untrusted.send_error.assert_called_with(403, "Access denied")
         
-        # Test trusted embassy proxy IP: returns 200
+        # Test trusted embassy proxy IP (with standard .local Host): returns 200
         wfile_trusted = BytesIO()
         handler_trusted = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
         handler_trusted.client_address = ("172.18.0.1", 12345)
@@ -94,6 +94,45 @@ class TestHTTPHandler(unittest.TestCase):
         bridge.DashboardHTTPRequestHandler.do_GET(handler_trusted)
         handler_trusted.send_error.assert_not_called()
         handler_trusted.send_response.assert_called_with(200)
+
+        # Test trusted embassy proxy IP (with RFC 1918 private IP Host): returns 200
+        wfile_ip = BytesIO()
+        handler_ip = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+        handler_ip.client_address = ("172.18.0.1", 12345)
+        handler_ip.path = "/api/status"
+        handler_ip.headers = DummyHeaders({
+            "Host": "192.168.1.150:443",
+            "X-Forwarded-For": "1.2.3.4",
+            "X-Forwarded-Host": "192.168.1.150"
+        })
+        handler_ip.wfile = wfile_ip
+        handler_ip.send_response = MagicMock()
+        handler_ip.send_header = MagicMock()
+        handler_ip.end_headers = MagicMock()
+        handler_ip.send_error = MagicMock()
+        
+        bridge.DashboardHTTPRequestHandler.do_GET(handler_ip)
+        handler_ip.send_error.assert_not_called()
+        handler_ip.send_response.assert_called_with(200)
+
+        # Test trusted embassy proxy IP (with invalid public IP Host): returns 403
+        wfile_pub_ip = BytesIO()
+        handler_pub_ip = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+        handler_pub_ip.client_address = ("172.18.0.1", 12345)
+        handler_pub_ip.path = "/api/status"
+        handler_pub_ip.headers = DummyHeaders({
+            "Host": "8.8.8.8",
+            "X-Forwarded-For": "1.2.3.4",
+            "X-Forwarded-Host": "8.8.8.8"
+        })
+        handler_pub_ip.wfile = wfile_pub_ip
+        handler_pub_ip.send_response = MagicMock()
+        handler_pub_ip.send_header = MagicMock()
+        handler_pub_ip.end_headers = MagicMock()
+        handler_pub_ip.send_error = MagicMock()
+        
+        bridge.DashboardHTTPRequestHandler.do_GET(handler_pub_ip)
+        handler_pub_ip.send_error.assert_called_with(403, "Access denied")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_http_handler.py
+++ b/tests/test_http_handler.py
@@ -1,0 +1,99 @@
+import unittest
+import os
+import sys
+import json
+from unittest.mock import patch, MagicMock
+from io import BytesIO
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import bridge
+
+class DummyHeaders:
+    def __init__(self, headers):
+        self.headers = {k.lower(): v for k, v in headers.items()}
+    def get(self, name, default=None):
+        return self.headers.get(name.lower(), default)
+    def __contains__(self, name):
+        return name.lower() in self.headers
+
+class TestHTTPHandler(unittest.TestCase):
+    @patch('bridge.get_default_gateway')
+    @patch('socket.gethostbyname')
+    @patch('bridge.get_status')
+    @patch('bridge.get_wg_pubkey')
+    def test_do_GET_api_status_authorization(self, mock_pubkey, mock_status, mock_gethostbyname, mock_get_gw):
+        mock_get_gw.return_value = "172.18.0.1"
+        mock_gethostbyname.return_value = "172.18.0.1"
+        mock_pubkey.return_value = "pubkey123"
+        mock_status.return_value = {
+            "status": "running",
+            "vpn_connected": True,
+            "handshake": "active"
+        }
+        
+        # Test local address: bypasses gateway check
+        req = MagicMock()
+        req.client_address = ("127.0.0.1", 12345)
+        req.path = "/api/status"
+        req.headers = DummyHeaders({"Host": "localhost"})
+        
+        wfile = BytesIO()
+        req.wfile = wfile
+        
+        handler = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+        handler.client_address = req.client_address
+        handler.path = req.path
+        handler.headers = req.headers
+        handler.wfile = wfile
+        handler.send_response = MagicMock()
+        handler.send_header = MagicMock()
+        handler.end_headers = MagicMock()
+        handler.send_error = MagicMock()
+        
+        bridge.DashboardHTTPRequestHandler.do_GET(handler)
+        
+        # Should NOT have sent an error
+        handler.send_error.assert_not_called()
+        handler.send_response.assert_called_with(200)
+        
+        # Test untrusted subnet peer container: returns 403
+        wfile_untrusted = BytesIO()
+        handler_untrusted = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+        handler_untrusted.client_address = ("172.18.0.3", 12345)
+        handler_untrusted.path = "/api/status"
+        handler_untrusted.headers = DummyHeaders({
+            "Host": "tunnelsats.local",
+            "X-Forwarded-For": "1.2.3.4",
+            "X-Forwarded-Host": "tunnelsats.local"
+        })
+        handler_untrusted.wfile = wfile_untrusted
+        handler_untrusted.send_response = MagicMock()
+        handler_untrusted.send_header = MagicMock()
+        handler_untrusted.end_headers = MagicMock()
+        handler_untrusted.send_error = MagicMock()
+        
+        bridge.DashboardHTTPRequestHandler.do_GET(handler_untrusted)
+        handler_untrusted.send_error.assert_called_with(403, "Access denied")
+        
+        # Test trusted embassy proxy IP: returns 200
+        wfile_trusted = BytesIO()
+        handler_trusted = bridge.DashboardHTTPRequestHandler.__new__(bridge.DashboardHTTPRequestHandler)
+        handler_trusted.client_address = ("172.18.0.1", 12345)
+        handler_trusted.path = "/api/status"
+        handler_trusted.headers = DummyHeaders({
+            "Host": "tunnelsats.local",
+            "X-Forwarded-For": "1.2.3.4",
+            "X-Forwarded-Host": "tunnelsats.local"
+        })
+        handler_trusted.wfile = wfile_trusted
+        handler_trusted.send_response = MagicMock()
+        handler_trusted.send_header = MagicMock()
+        handler_trusted.end_headers = MagicMock()
+        handler_trusted.send_error = MagicMock()
+        
+        bridge.DashboardHTTPRequestHandler.do_GET(handler_trusted)
+        handler_trusted.send_error.assert_not_called()
+        handler_trusted.send_response.assert_called_with(200)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -131,5 +131,53 @@ class TestBridgeLifecycle(unittest.TestCase):
         self.assertEqual(output["data"]["WireGuard Public Key"]["value"], "public_key_abc123")
         self.assertEqual(output["data"]["Internal IP (Last Octet)"]["value"], "45")
 
+    @patch('bridge.is_enabled')
+    @patch('bridge.vpn_up')
+    @patch('time.sleep')
+    @patch('sys.argv', ['bridge.py', 'start'])
+    def test_main_start_disabled(self, mock_sleep, mock_vpn_up, mock_is_enabled):
+        mock_is_enabled.return_value = False
+        mock_sleep.side_effect = KeyboardInterrupt("Stop loop")
+        
+        with self.assertRaises(KeyboardInterrupt):
+            bridge.main()
+            
+        mock_vpn_up.assert_not_called()
+
+    @patch('urllib.request.urlopen')
+    @patch('builtins.open', new_callable=unittest.mock.mock_open)
+    def test_lazy_sync_success(self, mock_open, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.read.return_value = b'{"expiry": "2026-12-31T23:59:59Z"}'
+        mock_response.__enter__ = lambda s: s
+        mock_response.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_response
+        
+        bridge.lazy_sync("mock_pubkey_123")
+        
+        mock_open.assert_called_with(bridge.META_FILE_PATH, 'w')
+        handle = mock_open()
+        written_data = "".join([call.args[0] for call in handle.write.call_args_list])
+        import json
+        parsed_written = json.loads(written_data)
+        self.assertEqual(parsed_written["expiresAt"], "2026-12-31T23:59:59Z")
+
+    @patch('builtins.open', new_callable=unittest.mock.mock_open, read_data='{"expiresAt": "2026-12-31T23:59:59Z"}')
+    @patch('os.path.exists')
+    @patch('bridge.datetime')
+    def test_format_subscription_expiry_active(self, mock_datetime, mock_exists, mock_open):
+        mock_exists.return_value = True
+        
+        # Mock current time: 2026-12-20 12:00:00 UTC
+        from datetime import datetime, timezone
+        fixed_now = datetime(2026, 12, 20, 12, 0, 0, tzinfo=timezone.utc)
+        mock_datetime.now.return_value = fixed_now
+        # Also need fromisoformat to work normally
+        mock_datetime.fromisoformat.side_effect = lambda s: datetime.fromisoformat(s)
+        
+        result = bridge.format_subscription_expiry()
+        self.assertEqual(result, "Active (Expires in 11d 11h)")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -119,7 +119,7 @@ class TestBridgeLifecycle(unittest.TestCase):
         mock_get_ip.return_value = "10.9.9.45"
         
         # Mock `wg pubkey`
-        mock_run.return_value = MagicMock(stdout=b'public_key_abc123\n')
+        mock_run.return_value = MagicMock(stdout=b'public_key_abc123\n', returncode=0)
         
         bridge.get_properties()
         

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -109,11 +109,13 @@ class TestBridgeLifecycle(unittest.TestCase):
         valid_conf = "[Interface]\nPrivateKey = hidden_key\nAddress = 10.x.x.x/32\n# Port Forwarding: 54321\n[Peer]\nEndpoint = 198.51.100.1:51820"
         bridge.validate_config(valid_conf) # Should work cleanly now
 
+    @patch('os.path.exists')
     @patch('bridge.get_wg_ip')
     @patch('subprocess.run')
     @patch('builtins.open', new_callable=unittest.mock.mock_open, read_data='[Interface]\nPrivateKey = hidden_key\n# VPNPort: 54321\n[Peer]\nEndpoint = 198.51.100.1:51820')
     @patch('sys.stdout', new_callable=unittest.mock.MagicMock)
-    def test_get_properties_success(self, mock_stdout, mock_open, mock_run, mock_get_ip):
+    def test_get_properties_success(self, mock_stdout, mock_open, mock_run, mock_get_ip, mock_exists):
+        mock_exists.return_value = True
         mock_get_ip.return_value = "10.9.9.45"
         
         # Mock `wg pubkey`

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -144,9 +144,10 @@ class TestBridgeLifecycle(unittest.TestCase):
             
         mock_vpn_up.assert_not_called()
 
+    @patch('os.replace')
     @patch('urllib.request.urlopen')
     @patch('builtins.open', new_callable=unittest.mock.mock_open)
-    def test_lazy_sync_success(self, mock_open, mock_urlopen):
+    def test_lazy_sync_success(self, mock_open, mock_urlopen, mock_replace):
         mock_response = MagicMock()
         mock_response.status = 200
         mock_response.read.return_value = b'{"expiry": "2026-12-31T23:59:59Z"}'
@@ -156,7 +157,7 @@ class TestBridgeLifecycle(unittest.TestCase):
         
         bridge.lazy_sync("mock_pubkey_123")
         
-        mock_open.assert_called_with(bridge.META_FILE_PATH, 'w')
+        mock_open.assert_called_with(bridge.META_FILE_PATH + ".tmp", 'w')
         handle = mock_open()
         written_data = "".join([call.args[0] for call in handle.write.call_args_list])
         import json

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -52,5 +52,37 @@ class TestBridgeStatus(unittest.TestCase):
         self.assertFalse(status["vpn_connected"])
         self.assertEqual(status["handshake"], "none")
 
+    @patch('bridge.is_enabled')
+    @patch('sys.stdout', new_callable=MagicMock)
+    @patch('sys.argv', ['bridge.py', 'health', 'vpn'])
+    def test_health_vpn_disabled(self, mock_stdout, mock_is_enabled):
+        mock_is_enabled.return_value = False
+        
+        with self.assertRaises(SystemExit) as cm:
+            bridge.main()
+            
+        self.assertEqual(cm.exception.code, 0)
+        
+        args, kwargs = mock_stdout.write.call_args_list[0]
+        import json
+        output = json.loads(args[0])
+        self.assertEqual(output["result"], "ok")
+
+    @patch('bridge.is_enabled')
+    @patch('sys.stdout', new_callable=MagicMock)
+    @patch('sys.argv', ['bridge.py', 'health', 'proxy'])
+    def test_health_proxy_disabled(self, mock_stdout, mock_is_enabled):
+        mock_is_enabled.return_value = False
+        
+        with self.assertRaises(SystemExit) as cm:
+            bridge.main()
+            
+        self.assertEqual(cm.exception.code, 0)
+        
+        args, kwargs = mock_stdout.write.call_args_list[0]
+        import json
+        output = json.loads(args[0])
+        self.assertEqual(output["result"], "ok")
+
 if __name__ == '__main__':
     unittest.main()

--- a/web/index.html
+++ b/web/index.html
@@ -1,16 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TunnelSats Dashboard</title>
-    <meta name="description" content="TunnelSats VPN dashboard for Lightning Network nodes on StartOS. Monitor tunnel status, subscription expiry, and connection properties.">
+    <meta name="description"
+        content="TunnelSats VPN dashboard for Lightning Network nodes on StartOS. Monitor tunnel status, subscription expiry, and connection properties.">
     <!-- Outfit, Inter & JetBrains Mono Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+        rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
+
 <body>
     <div class="background-glow"></div>
     <div class="dashboard-container">
@@ -101,9 +106,10 @@
                         <button class="tab-btn" onclick="switchTab('cln-tab', this)">Core Lightning (CLN)</button>
                     </div>
                 </div>
-                
+
                 <div class="tab-content active" id="lnd-tab">
-                    <p class="guide-intro">Configure LND to announce the TunnelSats public IP and port, while ensuring normal routing for Tor/clearnet peers.</p>
+                    <p class="guide-intro">Configure LND to announce the TunnelSats public IP and port, while ensuring
+                        normal routing for Tor/clearnet peers.</p>
                     <div class="code-block-header">
                         <span>Append to your <code>lnd.conf</code>:</span>
                         <button class="btn-copy-code" onclick="copyCode('lnd-code', this)">Copy Block</button>
@@ -115,44 +121,54 @@ externalhosts=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highl
 tor.skip-proxy-for-clearnet-targets=true
 tor.streamisolation=false</code></pre>
                     <div class="warning-box">
-                        <strong>Important Note:</strong> Restart the LND service on StartOS after modifying its config file to apply the new announced address.
+                        <strong>Important Note:</strong> Restart the LND service on StartOS after modifying its config
+                        file to apply the new announced address.
                     </div>
                 </div>
 
                 <div class="tab-content" id="cln-tab">
-                    <p class="guide-intro">Configure Core Lightning to announce your TunnelSats external IP and port for inbound peer-to-peer connections.</p>
+                    <p class="guide-intro">Configure Core Lightning to announce your TunnelSats external IP and port for
+                        inbound peer-to-peer connections.</p>
                     <div class="code-block-header">
                         <span>Append to your CLN <code>config</code> file:</span>
                         <button class="btn-copy-code" onclick="copyCode('cln-code', this)">Copy Block</button>
                     </div>
                     <pre><code id="cln-code">announce-addr=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span></code></pre>
                     <div class="warning-box">
-                        <strong>Important Note:</strong> Restart the Core Lightning service on StartOS after saving these modifications.
+                        <strong>Important Note:</strong> Restart the Core Lightning service on StartOS after saving
+                        these modifications.
                     </div>
                 </div>
             </section>
         </main>
-        
+
         <footer class="dashboard-footer">
             <div class="footer-links">
                 <a href="https://tunnelsats.com" target="_blank" rel="noopener" class="footer-link" id="link-website">
-                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <circle cx="12" cy="12" r="10"></circle>
                         <line x1="2" y1="12" x2="22" y2="12"></line>
-                        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+                        <path
+                            d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z">
+                        </path>
                     </svg>
                     TunnelSats.com
                 </a>
                 <span class="footer-divider" aria-hidden="true">·</span>
-                <a href="https://status.tunnelsats.com" target="_blank" rel="noopener" class="footer-link" id="link-status">
-                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <a href="https://tunnelsats.com/status" target="_blank" rel="noopener" class="footer-link"
+                    id="link-status">
+                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
                     </svg>
                     Server Status
                 </a>
                 <span class="footer-divider" aria-hidden="true">·</span>
-                <button class="footer-link footer-btn-faq" id="btn-open-faq" onclick="openFaqModal()" aria-haspopup="dialog">
-                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <button class="footer-link footer-btn-faq" id="btn-open-faq" onclick="openFaqModal()"
+                    aria-haspopup="dialog">
+                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <circle cx="12" cy="12" r="10"></circle>
                         <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
                         <line x1="12" y1="17" x2="12.01" y2="17"></line>
@@ -170,7 +186,8 @@ tor.streamisolation=false</code></pre>
         <div class="faq-dialog-inner">
             <div class="faq-modal-header">
                 <div class="faq-modal-title-row">
-                    <svg class="faq-title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <svg class="faq-title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <circle cx="12" cy="12" r="10"></circle>
                         <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
                         <line x1="12" y1="17" x2="12.01" y2="17"></line>
@@ -178,7 +195,8 @@ tor.streamisolation=false</code></pre>
                     <h2 id="faq-modal-title">Frequently Asked Questions</h2>
                 </div>
                 <button class="faq-close-btn" id="btn-close-faq" onclick="closeFaqModal()" aria-label="Close FAQ">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"
+                        stroke-linejoin="round" aria-hidden="true">
                         <line x1="18" y1="6" x2="6" y2="18"></line>
                         <line x1="6" y1="6" x2="18" y2="18"></line>
                     </svg>
@@ -190,59 +208,90 @@ tor.streamisolation=false</code></pre>
                 <details class="faq-item">
                     <summary class="faq-question">How do I activate my TunnelSats subscription?</summary>
                     <div class="faq-answer">
-                        <p>You need two things: your WireGuard <code>.conf</code> file and the <strong>Enable TunnelSats</strong> toggle.</p>
+                        <p>You need two things: your WireGuard <code>.conf</code> file and the <strong>Enable
+                                TunnelSats</strong> toggle.</p>
                         <ol>
                             <li>Open the <strong>TunnelSats config page</strong> in StartOS (⚙ → Configure).</li>
-                            <li>Log in to <a href="https://tunnelsats.com" target="_blank" rel="noopener">tunnelsats.com</a>, download your <code>.conf</code> file, and paste its full contents into the <strong>WireGuard Configuration</strong> field.</li>
+                            <li>Log in to <a href="https://tunnelsats.com" target="_blank"
+                                    rel="noopener">tunnelsats.com</a>, download your <code>.conf</code> file, and paste
+                                its full contents into the <strong>WireGuard Configuration</strong> field.</li>
                             <li>Set the <strong>Enable TunnelSats</strong> toggle to <strong>On</strong>.</li>
                             <li>Select your Lightning node (LND or Core Lightning) and click <strong>Save</strong>.</li>
                         </ol>
-                        <p class="faq-note">⚡ Don't forget to also update your <code>lnd.conf</code> or CLN config file — see the <em>Setup Guides</em> section on this dashboard for the exact lines to add.</p>
+                        <p class="faq-note">⚡ Don't forget to also update your <code>lnd.conf</code> or CLN config file
+                            — see the <em>Setup Guides</em> section on this dashboard for the exact lines to add.</p>
                     </div>
                 </details>
 
                 <!-- Q2 -->
                 <details class="faq-item">
-                    <summary class="faq-question">I saved my config but the tunnel shows "Disconnected" — what do I do?</summary>
+                    <summary class="faq-question">I saved my config but the tunnel shows "Disconnected" — what do I do?
+                    </summary>
                     <div class="faq-answer">
                         <p>This is the most common setup issue. Work through these checks in order:</p>
                         <ol>
-                            <li><strong>Check the Enable toggle.</strong> Go to ⚙ → Configure and confirm <em>Enable TunnelSats</em> is <strong>On</strong>. Saving the config does not automatically enable the tunnel.</li>
-                            <li><strong>Verify your lnd.conf / CLN config.</strong> The tunnel can be connected but your Lightning node won't broadcast correctly until you've added the <code>externalhosts=</code> (LND) or <code>announce-addr=</code> (CLN) lines and restarted the service.</li>
-                            <li><strong>Check the VPN endpoint.</strong> The WireGuard handshake needs outbound internet access. If your node is behind a strict firewall, UDP port 51820 must be reachable.</li>
-                            <li><strong>Restart the TunnelSats service.</strong> In StartOS, stop and restart TunnelSats after any config change.</li>
+                            <li><strong>Check the Enable toggle.</strong> Go to ⚙ → Configure and confirm <em>Enable
+                                    TunnelSats</em> is <strong>On</strong>. Saving the config does not automatically
+                                enable the tunnel.</li>
+                            <li><strong>Verify your lnd.conf / CLN config.</strong> The tunnel can be connected but your
+                                Lightning node won't broadcast correctly until you've added the
+                                <code>externalhosts=</code> (LND) or <code>announce-addr=</code> (CLN) lines and
+                                restarted the service.
+                            </li>
+                            <li><strong>Check the VPN endpoint.</strong> The WireGuard handshake needs outbound internet
+                                access. If your node is behind a strict firewall, UDP port 51820 must be reachable.</li>
+                            <li><strong>Restart the TunnelSats service.</strong> In StartOS, stop and restart TunnelSats
+                                after any config change.</li>
                         </ol>
-                        <p class="faq-note">Still stuck? Open an issue on <a href="https://github.com/Tunnelsats/tunnelsats-startos/issues/new" target="_blank" rel="noopener">GitHub</a> with your dashboard status screenshot.</p>
+                        <p class="faq-note">Still stuck? Open an issue on <a
+                                href="https://github.com/Tunnelsats/tunnelsats-startos/issues/new" target="_blank"
+                                rel="noopener">GitHub</a> with your dashboard status screenshot.</p>
                     </div>
                 </details>
 
                 <!-- Q3 -->
                 <details class="faq-item">
-                    <summary class="faq-question">How do I add the externalhosts / announce-addr lines to my Lightning node?</summary>
+                    <summary class="faq-question">How do I add the externalhosts / announce-addr lines to my Lightning
+                        node?</summary>
                     <div class="faq-answer">
-                        <p>On StartOS, there is <strong>no UI field</strong> in the LND or CLN config pages for custom external hosts — you need to edit the config files directly via SSH. The files live in the persistent data volume, so your changes survive restarts and updates.</p>
+                        <p>On StartOS, there is <strong>no UI field</strong> in the LND or CLN config pages for custom
+                            external hosts — you need to edit the config files directly via SSH. The files live in the
+                            persistent data volume, so your changes survive restarts and updates.</p>
 
                         <p><strong>Step 1: SSH into your StartOS node</strong></p>
                         <p>Use a terminal on your computer:</p>
-                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">ssh start9@&lt;your-node-ip&gt;</code></pre>
+                        <pre
+                            style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">ssh start9@&lt;your-node-ip&gt;</code></pre>
 
                         <p style="margin-top:12px;"><strong>For LND</strong> — edit <code>lnd.conf</code>:</p>
-                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">sudo nano /embassy-data/package-data/volumes/lnd/data/main/lnd.conf</code></pre>
-                        <p style="margin-top:8px;">Add these lines under <code>[Application Options]</code> — replace with your actual values from the <em>Connection Properties</em> section above:</p>
-                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">externalhosts=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span>
+                        <pre
+                            style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">sudo nano /embassy-data/package-data/volumes/lnd/data/main/lnd.conf</code></pre>
+                        <p style="margin-top:8px;">Add these lines under <code>[Application Options]</code> — replace
+                            with your actual values from the <em>Connection Properties</em> section above:</p>
+                        <pre
+                            style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">externalhosts=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span>
 
 # [tor]
 tor.skip-proxy-for-clearnet-targets=true
 tor.streamisolation=false</code></pre>
-                        <p style="margin-top:8px;">Save with <kbd>Ctrl+O</kbd>, exit with <kbd>Ctrl+X</kbd>, then restart LND in the StartOS UI.</p>
+                        <p style="margin-top:8px;">Save with <kbd>Ctrl+O</kbd>, exit with <kbd>Ctrl+X</kbd>, then
+                            restart LND in the StartOS UI.</p>
 
-                        <p style="margin-top:12px;"><strong>For Core Lightning (CLN)</strong> — edit the <code>config</code> file:</p>
-                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">sudo nano /embassy-data/package-data/volumes/c-lightning/data/main/config</code></pre>
+                        <p style="margin-top:12px;"><strong>For Core Lightning (CLN)</strong> — edit the
+                            <code>config</code> file:
+                        </p>
+                        <pre
+                            style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">sudo nano /embassy-data/package-data/volumes/c-lightning/data/main/config</code></pre>
                         <p style="margin-top:8px;">Add this line at the end — replace with your actual values:</p>
-                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">announce-addr=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span></code></pre>
+                        <pre
+                            style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">announce-addr=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span></code></pre>
                         <p style="margin-top:8px;">Save, then restart Core Lightning in the StartOS UI.</p>
 
-                        <p class="faq-note">⚠️ <strong>Important:</strong> These changes persist in the volume but may be overwritten if you use StartOS's own LND/CLN config UI to save settings. If you save via the StartOS UI after making these changes, re-apply the lines above and restart the node again. Use the <strong>Copy</strong> buttons in Connection Properties to get your exact IP and port.</p>
+                        <p class="faq-note">⚠️ <strong>Important:</strong> These changes persist in the volume but may
+                            be overwritten if you use StartOS's own LND/CLN config UI to save settings. If you save via
+                            the StartOS UI after making these changes, re-apply the lines above and restart the node
+                            again. Use the <strong>Copy</strong> buttons in Connection Properties to get your exact IP
+                            and port.</p>
                     </div>
                 </details>
 
@@ -251,46 +300,71 @@ tor.streamisolation=false</code></pre>
                 <details class="faq-item">
                     <summary class="faq-question">Is TunnelSats a general VPN for all my StartOS traffic?</summary>
                     <div class="faq-answer">
-                        <p><strong>No.</strong> TunnelSats is purpose-built exclusively for Lightning Network routing.</p>
-                        <p>It tunnels only your Lightning node's <strong>inbound peer connections</strong> (LND or CLN) — not your Bitcoin node, not your other StartOS apps, and not your general internet traffic. Your Bitcoin node (bitcoind) continues to use Tor as normal.</p>
-                        <p>This is by design: TunnelSats gives your Lightning node a stable, reachable clearnet identity for channel gossip, without exposing your home IP or routing all your traffic through a third party.</p>
-                        <p class="faq-note">If you need a general-purpose VPN for all StartOS system traffic, look for WireGuard or OpenVPN packages in the StartOS app store.</p>
+                        <p><strong>No.</strong> TunnelSats is purpose-built exclusively for Lightning Network routing.
+                        </p>
+                        <p>It tunnels only your Lightning node's <strong>inbound peer connections</strong> (LND or CLN)
+                            — not your Bitcoin node, not your other StartOS apps, and not your general internet traffic.
+                            Your Bitcoin node (bitcoind) continues to use Tor as normal.</p>
+                        <p>This is by design: TunnelSats gives your Lightning node a stable, reachable clearnet identity
+                            for channel gossip, without exposing your home IP or routing all your traffic through a
+                            third party.</p>
+                        <p class="faq-note">If you need a general-purpose VPN for all StartOS system traffic, look for
+                            WireGuard or OpenVPN packages in the StartOS app store.</p>
                     </div>
                 </details>
 
                 <!-- Q5 -->
                 <details class="faq-item">
-                    <summary class="faq-question">What happens if my subscription expires while the tunnel is active?</summary>
+                    <summary class="faq-question">What happens if my subscription expires while the tunnel is active?
+                    </summary>
                     <div class="faq-answer">
                         <p>This is the most important thing to plan for. When your subscription expires:</p>
                         <ol>
-                            <li>The WireGuard tunnel drops — your node can no longer receive inbound connections via the TunnelSats IP.</li>
-                            <li>However, your Lightning node's config files (<code>externalhosts=</code> / <code>announce-addr=</code>) still point to that now-dead IP.</li>
-                            <li>Your node will broadcast an <strong>unreachable address</strong> to the network, causing peers to fail to connect and potentially affecting channel health.</li>
+                            <li>The WireGuard tunnel drops — your node can no longer receive inbound connections via the
+                                TunnelSats IP.</li>
+                            <li>However, your Lightning node's config files (<code>externalhosts=</code> /
+                                <code>announce-addr=</code>) still point to that now-dead IP.
+                            </li>
+                            <li>Your node will broadcast an <strong>unreachable address</strong> to the network, causing
+                                peers to fail to connect and potentially affecting channel health.</li>
                         </ol>
                         <p><strong>What to do before expiry:</strong></p>
                         <ul>
-                            <li>Watch the countdown timer on this dashboard — it turns amber when under 30 days remain.</li>
-                            <li>Renew at <a href="https://tunnelsats.com" target="_blank" rel="noopener">tunnelsats.com</a> and paste your new config before the old one expires.</li>
-                            <li>Or, if you won't renew: disable TunnelSats via ⚙ → Configure (set Enable to Off), remove the <code>externalhosts=</code> / <code>announce-addr=</code> lines from your node config, and restart your Lightning node.</li>
+                            <li>Watch the countdown timer on this dashboard — it turns amber when under 30 days remain.
+                            </li>
+                            <li>Renew at <a href="https://tunnelsats.com" target="_blank"
+                                    rel="noopener">tunnelsats.com</a> and paste your new config before the old one
+                                expires.</li>
+                            <li>Or, if you won't renew: disable TunnelSats via ⚙ → Configure (set Enable to Off), remove
+                                the <code>externalhosts=</code> / <code>announce-addr=</code> lines from your node
+                                config, and restart your Lightning node.</li>
                         </ul>
                     </div>
                 </details>
 
                 <!-- Q6 -->
                 <details class="faq-item">
-                    <summary class="faq-question">Are my WireGuard config and settings preserved if I uninstall the app?</summary>
+                    <summary class="faq-question">Are my WireGuard config and settings preserved if I uninstall the app?
+                    </summary>
                     <div class="faq-answer">
-                        <p><strong>No — uninstalling TunnelSats from StartOS will delete your configuration data</strong>, including your pasted WireGuard config and the enabled/disabled state.</p>
-                        <p>This is a StartOS platform behaviour: when a package is uninstalled, its data volume (<code>/data</code>) is removed along with the container.</p>
+                        <p><strong>No — uninstalling TunnelSats from StartOS will delete your configuration
+                                data</strong>, including your pasted WireGuard config and the enabled/disabled state.
+                        </p>
+                        <p>This is a StartOS platform behaviour: when a package is uninstalled, its data volume
+                            (<code>/data</code>) is removed along with the container.</p>
                         <p><strong>Before uninstalling, you should:</strong></p>
                         <ol>
-                            <li>Copy your WireGuard <code>.conf</code> content from ⚙ → Configure → WireGuard Configuration and save it somewhere safe.</li>
-                            <li>Disable the TunnelSats tunnel (set Enable to Off and save) so your Lightning node falls back to Tor/clearnet.</li>
-                            <li>Remove the <code>externalhosts=</code> / <code>announce-addr=</code> lines from your Lightning node config and restart it.</li>
+                            <li>Copy your WireGuard <code>.conf</code> content from ⚙ → Configure → WireGuard
+                                Configuration and save it somewhere safe.</li>
+                            <li>Disable the TunnelSats tunnel (set Enable to Off and save) so your Lightning node falls
+                                back to Tor/clearnet.</li>
+                            <li>Remove the <code>externalhosts=</code> / <code>announce-addr=</code> lines from your
+                                Lightning node config and restart it.</li>
                             <li>Only then uninstall TunnelSats.</li>
                         </ol>
-                        <p class="faq-note">⚠ Your subscription itself (purchased at tunnelsats.com) is not affected by uninstalling the StartOS app. If you reinstall, simply paste your <code>.conf</code> file again.</p>
+                        <p class="faq-note">⚠ Your subscription itself (purchased at tunnelsats.com) is not affected by
+                            uninstalling the StartOS app. If you reinstall, simply paste your <code>.conf</code> file
+                            again.</p>
                     </div>
                 </details>
 
@@ -300,7 +374,8 @@ tor.streamisolation=false</code></pre>
                     <div class="faq-answer">
                         <p>The best place is the <strong>GitHub Issues</strong> tracker for this package:</p>
                         <p>
-                            <a href="https://github.com/Tunnelsats/tunnelsats-startos/issues/new" target="_blank" rel="noopener" class="faq-cta-link" id="link-github-issue">
+                            <a href="https://github.com/Tunnelsats/tunnelsats-startos/issues/new" target="_blank"
+                                rel="noopener" class="faq-cta-link" id="link-github-issue">
                                 → Open a new issue on GitHub
                             </a>
                         </p>
@@ -311,7 +386,8 @@ tor.streamisolation=false</code></pre>
                             <li>A screenshot of this dashboard's status section</li>
                             <li>Any error messages shown in the StartOS logs for TunnelSats</li>
                         </ul>
-                        <p>For subscription and account questions, contact <a href="https://tunnelsats.com" target="_blank" rel="noopener">tunnelsats.com</a> support directly.</p>
+                        <p>For subscription and account questions, contact <a href="https://tunnelsats.com"
+                                target="_blank" rel="noopener">tunnelsats.com</a> support directly.</p>
                     </div>
                 </details>
             </div><!-- /faq-body -->
@@ -320,4 +396,5 @@ tor.streamisolation=false</code></pre>
 
     <script src="script.js"></script>
 </body>
+
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>TunnelSats Dashboard</title>
+    <meta name="description" content="TunnelSats VPN dashboard for Lightning Network nodes on StartOS. Monitor tunnel status, subscription expiry, and connection properties.">
     <!-- Outfit, Inter & JetBrains Mono Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -133,9 +134,182 @@ tor.streamisolation=false</code></pre>
         </main>
         
         <footer class="dashboard-footer">
-            <p>Need to renew? Visit the official <a href="https://tunnelsats.com" target="_blank" rel="noopener">TunnelSats Website</a></p>
+            <div class="footer-links">
+                <a href="https://tunnelsats.com" target="_blank" rel="noopener" class="footer-link" id="link-website">
+                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <line x1="2" y1="12" x2="22" y2="12"></line>
+                        <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+                    </svg>
+                    TunnelSats.com
+                </a>
+                <span class="footer-divider" aria-hidden="true">·</span>
+                <a href="https://status.tunnelsats.com" target="_blank" rel="noopener" class="footer-link" id="link-status">
+                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>
+                    </svg>
+                    Server Status
+                </a>
+                <span class="footer-divider" aria-hidden="true">·</span>
+                <button class="footer-link footer-btn-faq" id="btn-open-faq" onclick="openFaqModal()" aria-haspopup="dialog">
+                    <svg class="footer-link-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                    </svg>
+                    FAQ &amp; Help
+                </button>
+            </div>
         </footer>
     </div>
+
+    <!-- ════════════════════════════════════════════ -->
+    <!-- FAQ Modal                                    -->
+    <!-- ════════════════════════════════════════════ -->
+    <dialog id="faq-modal" class="faq-modal" aria-labelledby="faq-modal-title" aria-modal="true">
+        <div class="faq-dialog-inner">
+            <div class="faq-modal-header">
+                <div class="faq-modal-title-row">
+                    <svg class="faq-title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="10"></circle>
+                        <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path>
+                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                    </svg>
+                    <h2 id="faq-modal-title">Frequently Asked Questions</h2>
+                </div>
+                <button class="faq-close-btn" id="btn-close-faq" onclick="closeFaqModal()" aria-label="Close FAQ">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+
+            <div class="faq-body">
+                <!-- Q1 -->
+                <details class="faq-item">
+                    <summary class="faq-question">How do I activate my TunnelSats subscription?</summary>
+                    <div class="faq-answer">
+                        <p>You need two things: your WireGuard <code>.conf</code> file and the <strong>Enable TunnelSats</strong> toggle.</p>
+                        <ol>
+                            <li>Open the <strong>TunnelSats config page</strong> in StartOS (⚙ → Configure).</li>
+                            <li>Log in to <a href="https://tunnelsats.com" target="_blank" rel="noopener">tunnelsats.com</a>, download your <code>.conf</code> file, and paste its full contents into the <strong>WireGuard Configuration</strong> field.</li>
+                            <li>Set the <strong>Enable TunnelSats</strong> toggle to <strong>On</strong>.</li>
+                            <li>Select your Lightning node (LND or Core Lightning) and click <strong>Save</strong>.</li>
+                        </ol>
+                        <p class="faq-note">⚡ Don't forget to also update your <code>lnd.conf</code> or CLN config file — see the <em>Setup Guides</em> section on this dashboard for the exact lines to add.</p>
+                    </div>
+                </details>
+
+                <!-- Q2 -->
+                <details class="faq-item">
+                    <summary class="faq-question">I saved my config but the tunnel shows "Disconnected" — what do I do?</summary>
+                    <div class="faq-answer">
+                        <p>This is the most common setup issue. Work through these checks in order:</p>
+                        <ol>
+                            <li><strong>Check the Enable toggle.</strong> Go to ⚙ → Configure and confirm <em>Enable TunnelSats</em> is <strong>On</strong>. Saving the config does not automatically enable the tunnel.</li>
+                            <li><strong>Verify your lnd.conf / CLN config.</strong> The tunnel can be connected but your Lightning node won't broadcast correctly until you've added the <code>externalhosts=</code> (LND) or <code>announce-addr=</code> (CLN) lines and restarted the service.</li>
+                            <li><strong>Check the VPN endpoint.</strong> The WireGuard handshake needs outbound internet access. If your node is behind a strict firewall, UDP port 51820 must be reachable.</li>
+                            <li><strong>Restart the TunnelSats service.</strong> In StartOS, stop and restart TunnelSats after any config change.</li>
+                        </ol>
+                        <p class="faq-note">Still stuck? Open an issue on <a href="https://github.com/Tunnelsats/tunnelsats-startos/issues/new" target="_blank" rel="noopener">GitHub</a> with your dashboard status screenshot.</p>
+                    </div>
+                </details>
+
+                <!-- Q3 -->
+                <details class="faq-item">
+                    <summary class="faq-question">Where do I find and edit my lnd.conf and CLN config files?</summary>
+                    <div class="faq-answer">
+                        <p>On StartOS, Lightning node config files are managed through the node's own configuration page, not by editing files directly.</p>
+                        <p><strong>For LND:</strong></p>
+                        <ol>
+                            <li>In the StartOS dashboard, click on <strong>LND</strong>.</li>
+                            <li>Go to <strong>⚙ Configure → Advanced → Additional Arguments</strong>.</li>
+                            <li>Add the lines shown in the <em>LND Setup Guide</em> tab on this dashboard (with your actual IP and port filled in from Connection Properties above).</li>
+                            <li>Save and restart LND.</li>
+                        </ol>
+                        <p><strong>For Core Lightning (CLN):</strong></p>
+                        <ol>
+                            <li>In the StartOS dashboard, click on <strong>Core Lightning</strong>.</li>
+                            <li>Go to <strong>⚙ Configure</strong> and find the <strong>Additional Config</strong> field.</li>
+                            <li>Add the <code>announce-addr=</code> line shown in the <em>CLN Setup Guide</em> tab on this dashboard.</li>
+                            <li>Save and restart CLN.</li>
+                        </ol>
+                        <p class="faq-note">💡 Use the <strong>Copy</strong> buttons in the Connection Properties section above to copy your exact IP and port before editing.</p>
+                    </div>
+                </details>
+
+                <!-- Q4 -->
+                <details class="faq-item">
+                    <summary class="faq-question">Is TunnelSats a general VPN for all my StartOS traffic?</summary>
+                    <div class="faq-answer">
+                        <p><strong>No.</strong> TunnelSats is purpose-built exclusively for Lightning Network routing.</p>
+                        <p>It tunnels only your Lightning node's <strong>inbound peer connections</strong> (LND or CLN) — not your Bitcoin node, not your other StartOS apps, and not your general internet traffic. Your Bitcoin node (bitcoind) continues to use Tor as normal.</p>
+                        <p>This is by design: TunnelSats gives your Lightning node a stable, reachable clearnet identity for channel gossip, without exposing your home IP or routing all your traffic through a third party.</p>
+                        <p class="faq-note">If you need a general-purpose VPN for all StartOS system traffic, look for WireGuard or OpenVPN packages in the StartOS app store.</p>
+                    </div>
+                </details>
+
+                <!-- Q5 -->
+                <details class="faq-item">
+                    <summary class="faq-question">What happens if my subscription expires while the tunnel is active?</summary>
+                    <div class="faq-answer">
+                        <p>This is the most important thing to plan for. When your subscription expires:</p>
+                        <ol>
+                            <li>The WireGuard tunnel drops — your node can no longer receive inbound connections via the TunnelSats IP.</li>
+                            <li>However, your Lightning node's config files (<code>externalhosts=</code> / <code>announce-addr=</code>) still point to that now-dead IP.</li>
+                            <li>Your node will broadcast an <strong>unreachable address</strong> to the network, causing peers to fail to connect and potentially affecting channel health.</li>
+                        </ol>
+                        <p><strong>What to do before expiry:</strong></p>
+                        <ul>
+                            <li>Watch the countdown timer on this dashboard — it turns amber when under 30 days remain.</li>
+                            <li>Renew at <a href="https://tunnelsats.com" target="_blank" rel="noopener">tunnelsats.com</a> and paste your new config before the old one expires.</li>
+                            <li>Or, if you won't renew: disable TunnelSats via ⚙ → Configure (set Enable to Off), remove the <code>externalhosts=</code> / <code>announce-addr=</code> lines from your node config, and restart your Lightning node.</li>
+                        </ul>
+                    </div>
+                </details>
+
+                <!-- Q6 -->
+                <details class="faq-item">
+                    <summary class="faq-question">Are my WireGuard config and settings preserved if I uninstall the app?</summary>
+                    <div class="faq-answer">
+                        <p><strong>No — uninstalling TunnelSats from StartOS will delete your configuration data</strong>, including your pasted WireGuard config and the enabled/disabled state.</p>
+                        <p>This is a StartOS platform behaviour: when a package is uninstalled, its data volume (<code>/data</code>) is removed along with the container.</p>
+                        <p><strong>Before uninstalling, you should:</strong></p>
+                        <ol>
+                            <li>Copy your WireGuard <code>.conf</code> content from ⚙ → Configure → WireGuard Configuration and save it somewhere safe.</li>
+                            <li>Disable the TunnelSats tunnel (set Enable to Off and save) so your Lightning node falls back to Tor/clearnet.</li>
+                            <li>Remove the <code>externalhosts=</code> / <code>announce-addr=</code> lines from your Lightning node config and restart it.</li>
+                            <li>Only then uninstall TunnelSats.</li>
+                        </ol>
+                        <p class="faq-note">⚠ Your subscription itself (purchased at tunnelsats.com) is not affected by uninstalling the StartOS app. If you reinstall, simply paste your <code>.conf</code> file again.</p>
+                    </div>
+                </details>
+
+                <!-- Q7 -->
+                <details class="faq-item">
+                    <summary class="faq-question">Where can I report a bug or ask a question?</summary>
+                    <div class="faq-answer">
+                        <p>The best place is the <strong>GitHub Issues</strong> tracker for this package:</p>
+                        <p>
+                            <a href="https://github.com/Tunnelsats/tunnelsats-startos/issues/new" target="_blank" rel="noopener" class="faq-cta-link" id="link-github-issue">
+                                → Open a new issue on GitHub
+                            </a>
+                        </p>
+                        <p>When reporting, please include:</p>
+                        <ul>
+                            <li>Your StartOS version</li>
+                            <li>The TunnelSats package version (shown in the StartOS app list)</li>
+                            <li>A screenshot of this dashboard's status section</li>
+                            <li>Any error messages shown in the StartOS logs for TunnelSats</li>
+                        </ul>
+                        <p>For subscription and account questions, contact <a href="https://tunnelsats.com" target="_blank" rel="noopener">tunnelsats.com</a> support directly.</p>
+                    </div>
+                </details>
+            </div><!-- /faq-body -->
+        </div><!-- /faq-dialog-inner -->
+    </dialog>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -218,26 +218,34 @@ tor.streamisolation=false</code></pre>
 
                 <!-- Q3 -->
                 <details class="faq-item">
-                    <summary class="faq-question">Where do I find and edit my lnd.conf and CLN config files?</summary>
+                    <summary class="faq-question">How do I add the externalhosts / announce-addr lines to my Lightning node?</summary>
                     <div class="faq-answer">
-                        <p>On StartOS, Lightning node config files are managed through the node's own configuration page, not by editing files directly.</p>
-                        <p><strong>For LND:</strong></p>
-                        <ol>
-                            <li>In the StartOS dashboard, click on <strong>LND</strong>.</li>
-                            <li>Go to <strong>⚙ Configure → Advanced → Additional Arguments</strong>.</li>
-                            <li>Add the lines shown in the <em>LND Setup Guide</em> tab on this dashboard (with your actual IP and port filled in from Connection Properties above).</li>
-                            <li>Save and restart LND.</li>
-                        </ol>
-                        <p><strong>For Core Lightning (CLN):</strong></p>
-                        <ol>
-                            <li>In the StartOS dashboard, click on <strong>Core Lightning</strong>.</li>
-                            <li>Go to <strong>⚙ Configure</strong> and find the <strong>Additional Config</strong> field.</li>
-                            <li>Add the <code>announce-addr=</code> line shown in the <em>CLN Setup Guide</em> tab on this dashboard.</li>
-                            <li>Save and restart CLN.</li>
-                        </ol>
-                        <p class="faq-note">💡 Use the <strong>Copy</strong> buttons in the Connection Properties section above to copy your exact IP and port before editing.</p>
+                        <p>On StartOS, there is <strong>no UI field</strong> in the LND or CLN config pages for custom external hosts — you need to edit the config files directly via SSH. The files live in the persistent data volume, so your changes survive restarts and updates.</p>
+
+                        <p><strong>Step 1: SSH into your StartOS node</strong></p>
+                        <p>Use a terminal on your computer:</p>
+                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">ssh start9@&lt;your-node-ip&gt;</code></pre>
+
+                        <p style="margin-top:12px;"><strong>For LND</strong> — edit <code>lnd.conf</code>:</p>
+                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">sudo nano /embassy-data/package-data/volumes/lnd/data/main/lnd.conf</code></pre>
+                        <p style="margin-top:8px;">Add these lines under <code>[Application Options]</code> — replace with your actual values from the <em>Connection Properties</em> section above:</p>
+                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">externalhosts=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span>
+
+# [tor]
+tor.skip-proxy-for-clearnet-targets=true
+tor.streamisolation=false</code></pre>
+                        <p style="margin-top:8px;">Save with <kbd>Ctrl+O</kbd>, exit with <kbd>Ctrl+X</kbd>, then restart LND in the StartOS UI.</p>
+
+                        <p style="margin-top:12px;"><strong>For Core Lightning (CLN)</strong> — edit the <code>config</code> file:</p>
+                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">sudo nano /embassy-data/package-data/volumes/c-lightning/data/main/config</code></pre>
+                        <p style="margin-top:8px;">Add this line at the end — replace with your actual values:</p>
+                        <pre style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:6px;padding:10px 12px;font-size:11.5px;overflow-x:auto;margin-top:8px;"><code style="font-family:'JetBrains Mono',monospace;color:#f3f4f6;">announce-addr=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span></code></pre>
+                        <p style="margin-top:8px;">Save, then restart Core Lightning in the StartOS UI.</p>
+
+                        <p class="faq-note">⚠️ <strong>Important:</strong> These changes persist in the volume but may be overwritten if you use StartOS's own LND/CLN config UI to save settings. If you save via the StartOS UI after making these changes, re-apply the lines above and restart the node again. Use the <strong>Copy</strong> buttons in Connection Properties to get your exact IP and port.</p>
                     </div>
                 </details>
+
 
                 <!-- Q4 -->
                 <details class="faq-item">

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TunnelSats Dashboard</title>
+    <!-- Outfit, Inter & JetBrains Mono Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="background-glow"></div>
+    <div class="dashboard-container">
+        <!-- Header -->
+        <header class="dashboard-header">
+            <div class="brand">
+                <img src="logo.svg" alt="TunnelSats Logo" class="brand-logo">
+                <div class="brand-text">
+                    <h1>TunnelSats</h1>
+                    <span class="subtext">Lightning Network VPN Router</span>
+                </div>
+            </div>
+            <div class="status-badge-container">
+                <span id="status-badge" class="status-badge inactive">
+                    <span class="pulse-dot"></span>
+                    <span class="status-text">TUNNEL INACTIVE</span>
+                </span>
+            </div>
+        </header>
+
+        <!-- Main Content Grid -->
+        <main class="dashboard-grid">
+            <!-- Subscription Card -->
+            <section class="card glass-card span-2 subscription-card">
+                <div class="card-header">
+                    <h2>Subscription Status</h2>
+                    <span class="info-label" id="expiry-date-raw">Unknown</span>
+                </div>
+                <div class="subscription-content">
+                    <div class="countdown-container">
+                        <span class="countdown-label">Time Remaining</span>
+                        <div class="countdown-timer" id="countdown-timer">Checking...</div>
+                    </div>
+                    <div class="progress-bar-container">
+                        <div class="progress-bar" id="subscription-progress" style="width: 0%;"></div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Connection Details Card -->
+            <section class="card glass-card span-2 properties-card">
+                <h2>Connection Properties</h2>
+                <div class="properties-grid">
+                    <div class="prop-item">
+                        <div class="prop-label">TunnelSats Public IP</div>
+                        <div class="prop-value-group">
+                            <span class="prop-value" id="val-public-ip">...</span>
+                            <button class="btn-copy" onclick="copyText('val-public-ip', this)">Copy</button>
+                        </div>
+                    </div>
+                    <div class="prop-item">
+                        <div class="prop-label">Forwarding Port</div>
+                        <div class="prop-value-group">
+                            <span class="prop-value" id="val-vpn-port">...</span>
+                            <button class="btn-copy" onclick="copyText('val-vpn-port', this)">Copy</button>
+                        </div>
+                    </div>
+                    <div class="prop-item">
+                        <div class="prop-label">WireGuard Public Key</div>
+                        <div class="prop-value-group">
+                            <span class="prop-value truncated" id="val-pubkey">...</span>
+                            <button class="btn-copy" onclick="copyText('val-pubkey', this)">Copy</button>
+                        </div>
+                    </div>
+                    <div class="prop-item">
+                        <div class="prop-label">Internal IP (Last Octet)</div>
+                        <div class="prop-value-group">
+                            <span class="prop-value" id="val-octet">...</span>
+                            <button class="btn-copy" onclick="copyText('val-octet', this)">Copy</button>
+                        </div>
+                    </div>
+                    <div class="prop-item">
+                        <div class="prop-label">SOCKS5 Proxy (Outbound)</div>
+                        <div class="prop-value-group">
+                            <span class="prop-value" id="val-socks5">127.0.0.1:1080</span>
+                            <button class="btn-copy" onclick="copyText('val-socks5', this)">Copy</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Documentation & Guides Card -->
+            <section class="card glass-card span-2 docs-card">
+                <div class="docs-header">
+                    <h2>Lightning Routing Setup Guides</h2>
+                    <div class="tabs">
+                        <button class="tab-btn active" onclick="switchTab('lnd-tab', this)">LND</button>
+                        <button class="tab-btn" onclick="switchTab('cln-tab', this)">Core Lightning (CLN)</button>
+                    </div>
+                </div>
+                
+                <div class="tab-content active" id="lnd-tab">
+                    <p class="guide-intro">Configure LND to announce the TunnelSats public IP and port, while ensuring normal routing for Tor/clearnet peers.</p>
+                    <div class="code-block-header">
+                        <span>Append to your <code>lnd.conf</code>:</span>
+                        <button class="btn-copy-code" onclick="copyCode('lnd-code', this)">Copy Block</button>
+                    </div>
+                    <pre><code id="lnd-code"># [Application Options]
+externalhosts=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span>
+
+# [tor]
+tor.skip-proxy-for-clearnet-targets=true
+tor.streamisolation=false</code></pre>
+                    <div class="warning-box">
+                        <strong>Important Note:</strong> Restart the LND service on StartOS after modifying its config file to apply the new announced address.
+                    </div>
+                </div>
+
+                <div class="tab-content" id="cln-tab">
+                    <p class="guide-intro">Configure Core Lightning to announce your TunnelSats external IP and port for inbound peer-to-peer connections.</p>
+                    <div class="code-block-header">
+                        <span>Append to your CLN <code>config</code> file:</span>
+                        <button class="btn-copy-code" onclick="copyCode('cln-code', this)">Copy Block</button>
+                    </div>
+                    <pre><code id="cln-code">announce-addr=<span class="highlight-ip">tunnelsats_ip</span>:<span class="highlight-port">tunnelsats_port</span></code></pre>
+                    <div class="warning-box">
+                        <strong>Important Note:</strong> Restart the Core Lightning service on StartOS after saving these modifications.
+                    </div>
+                </div>
+            </section>
+        </main>
+        
+        <footer class="dashboard-footer">
+            <p>Need to renew? Visit the official <a href="https://tunnelsats.com" target="_blank" rel="noopener">TunnelSats Website</a></p>
+        </footer>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -7,12 +7,7 @@
     <title>TunnelSats Dashboard</title>
     <meta name="description"
         content="TunnelSats VPN dashboard for Lightning Network nodes on StartOS. Monitor tunnel status, subscription expiry, and connection properties.">
-    <!-- Outfit, Inter & JetBrains Mono Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Outfit:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
-        rel="stylesheet">
+    <!-- System font fallbacks are used to ensure complete offline and Tor compatibility -->
     <link rel="stylesheet" href="style.css">
 </head>
 

--- a/web/logo.svg
+++ b/web/logo.svg
@@ -1,0 +1,354 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="1024"
+   height="1023"
+   viewBox="0 0 1024 1023"
+   sodipodi:docname="ts_logo_square.svg"
+   inkscape:version="1.4.2 (ebf0e94, 2025-05-08)"
+   inkscape:export-filename="ts_logo_square.png"
+   inkscape:export-xdpi="80.71875"
+   inkscape:export-ydpi="80.71875"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <linearGradient
+       id="linearGradient5825"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#facc15;stop-opacity:1;"
+         offset="0"
+         id="stop5825" />
+      <stop
+         style="stop-color:#d99015;stop-opacity:1;"
+         offset="0.82452083"
+         id="stop5826" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5822"
+       x="-0.033615736"
+       y="-0.033615736"
+       width="1.0672315"
+       height="1.0672315">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.5422735"
+         id="feGaussianBlur5822" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5823"
+       x="-0.073020196"
+       y="-0.073020196"
+       width="1.1460404"
+       height="1.1460404">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="13.712554"
+         id="feGaussianBlur5823" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5824"
+       x="-0.069531729"
+       y="-0.069531729"
+       width="1.1390635"
+       height="1.1390635">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="16.59219"
+         id="feGaussianBlur5824" />
+    </filter>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5825"
+       id="radialGradient5826"
+       cx="507.4407"
+       cy="522.383"
+       fx="507.4407"
+       fy="522.383"
+       r="187.1702"
+       gradientTransform="matrix(1,0,0,2.1513587,0,-601.45017)"
+       gradientUnits="userSpaceOnUse" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5826"
+       x="-0.01304445"
+       y="-0.0054420075"
+       width="1.0260889"
+       height="1.010884">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.4744371"
+         id="feGaussianBlur5826" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5827"
+       x="-0.013120243"
+       y="-0.0054289237"
+       width="1.0262405"
+       height="1.0108578">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.461703"
+         id="feGaussianBlur5827" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5828"
+       x="-0.13178927"
+       y="-0.061258625"
+       width="1.2635785"
+       height="1.1225173">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="20.555852"
+         id="feGaussianBlur5828" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5829"
+       x="-0.012331284"
+       y="-0.012331284"
+       width="1.0246626"
+       height="1.0246626">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.4079369"
+         id="feGaussianBlur5829" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5830"
+       x="-0.013308055"
+       y="-0.013308055"
+       width="1.0266161"
+       height="1.0266161">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.9900305"
+         id="feGaussianBlur5830" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5831"
+       x="-0.016878263"
+       y="-0.016878263"
+       width="1.0337565"
+       height="1.0337565">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="1.9519399"
+         id="feGaussianBlur5831" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5832"
+       x="-0.087725139"
+       y="-0.087725139"
+       width="1.1754503"
+       height="1.1754503">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="21.671432"
+         id="feGaussianBlur5832" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5833"
+       x="-0.091632219"
+       y="-0.091632219"
+       width="1.1832644"
+       height="1.1832644">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="17.910274"
+         id="feGaussianBlur5833" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5834"
+       x="-0.098168024"
+       y="-0.098168024"
+       width="1.196336"
+       height="1.196336">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="13.880462"
+         id="feGaussianBlur5834" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter5835"
+       x="-0.078855737"
+       y="-0.078855737"
+       width="1.1577115"
+       height="1.1577115">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="10.627229"
+         id="feGaussianBlur5835" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.5"
+     inkscape:cx="441"
+     inkscape:cy="504"
+     inkscape:window-width="2991"
+     inkscape:window-height="1215"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Rings"
+     style="display:inline">
+    <circle
+       style="display:inline;opacity:1;fill:none;stroke:#22c55e;stroke-width:28;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5834)"
+       id="circle5834"
+       cx="511.5"
+       cy="517.71887"
+       r="240.98024"
+       inkscape:label="Inner Circle blur out" />
+    <circle
+       style="display:inline;opacity:1;fill:none;stroke:#22c55e;stroke-width:25;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5835)"
+       id="circle5822"
+       cx="511.5"
+       cy="517.71887"
+       r="240.98024"
+       inkscape:label="Inner Circle blur" />
+    <circle
+       style="display:inline;opacity:1;fill:none;stroke:#22c55e;stroke-width:25;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5822)"
+       id="path5819"
+       cx="511.5"
+       cy="517.71887"
+       r="240.98024"
+       inkscape:label="Inner Circle" />
+    <circle
+       style="display:inline;opacity:1;mix-blend-mode:normal;fill:none;stroke:#22f25e;stroke-width:6.9;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5831)"
+       id="circle5831"
+       cx="511.5"
+       cy="517.71887"
+       r="240.98024"
+       inkscape:label="Inner Circle light" />
+    <circle
+       style="display:inline;opacity:1;fill:none;stroke:#facc15;stroke-width:28;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5833)"
+       id="circle5833"
+       cx="511.5"
+       cy="517.71887"
+       r="310.94226"
+       inkscape:label="Middle Circle blur out" />
+    <circle
+       style="display:inline;opacity:1;fill:none;stroke:#facc15;stroke-width:25;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5823)"
+       id="circle5820"
+       cx="511.5"
+       cy="517.71887"
+       r="310.94226"
+       inkscape:label="Middle Circle blur" />
+    <circle
+       style="display:inline;opacity:1;fill:none;stroke:#facc15;stroke-width:25;stroke-dasharray:none;stroke-opacity:1"
+       id="circle5823"
+       cx="511.5"
+       cy="517.71887"
+       r="310.94226"
+       inkscape:label="Middle Circle" />
+    <circle
+       style="display:inline;opacity:1;fill:none;stroke:#faba15;stroke-width:7;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5830)"
+       id="circle5830"
+       cx="511.5"
+       cy="517.71887"
+       r="310.94226"
+       inkscape:label="Middle Circle light" />
+    <circle
+       style="display:inline;opacity:1;mix-blend-mode:normal;fill:none;fill-opacity:1;stroke:#22c55e;stroke-width:28;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5832)"
+       id="circle5832"
+       cx="511.5"
+       cy="517.71887"
+       r="376.24014"
+       inkscape:label="Outer Circle blur out" />
+    <circle
+       style="display:inline;opacity:1;mix-blend-mode:normal;fill:none;fill-opacity:1;stroke:#22c55e;stroke-width:25;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5824)"
+       id="circle5821"
+       cx="511.5"
+       cy="517.71887"
+       r="376.24014"
+       inkscape:label="Outer Circle blur" />
+    <circle
+       style="display:inline;opacity:1;mix-blend-mode:normal;fill:none;fill-opacity:1;stroke:#22c55e;stroke-width:25;stroke-dasharray:none;stroke-opacity:1"
+       id="circle5824"
+       cx="511.5"
+       cy="517.71887"
+       r="376.24014"
+       inkscape:label="Outer Circle" />
+    <circle
+       style="display:inline;opacity:1;mix-blend-mode:normal;fill:none;fill-opacity:1;stroke:#22f25e;stroke-width:7;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter5829)"
+       id="circle5829"
+       cx="511.5"
+       cy="517.71887"
+       r="376.24014"
+       inkscape:label="Outer Circle light" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Zaps"
+     style="display:inline">
+    <path
+       style="display:inline;opacity:1;mix-blend-mode:multiply;fill:#666666;fill-opacity:1;stroke-width:1.03131;filter:url(#filter5828)"
+       d="m 682.48554,119.71277 -362.21502,456.78399 145.37559,4.77475 -129.22275,343.78168 358.18754,-464.0847 -142.96577,1.231 z"
+       id="path5818"
+       inkscape:label="Big Zap Blur"
+       sodipodi:nodetypes="ccccccc"
+       transform="matrix(1.118074,0,0,1.118074,-59.91555,-61.679842)" />
+    <path
+       style="display:inline;opacity:1;fill:url(#radialGradient5826);stroke-width:1.03131"
+       d="m 682.48554,119.71277 -362.21502,456.78399 145.37559,4.77475 -129.22275,343.78168 358.18754,-464.0847 -142.96577,1.231 z"
+       id="path5827"
+       inkscape:label="Big Zap"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="display:inline;opacity:1;mix-blend-mode:normal;fill:#d9a515;fill-opacity:1;stroke-width:1.03131;filter:url(#filter5826)"
+       d="M 641.63708,186.53698 370.36087,551.5568 487.79588,555.3797 389.59879,836.78398 578.55974,509.46593 464.09521,512.11352 Z"
+       id="path5824"
+       inkscape:label="small left Zap"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="display:inline;opacity:1;mix-blend-mode:normal;fill:#facc15;fill-opacity:1;stroke-width:1.03131;filter:url(#filter5827)"
+       d="m 642.64447,182.40688 -180.12095,330.71284 111.1342,-1.87471 -179.22538,317.3465 267.37974,-351.91094 -134.18325,0.22168 z"
+       id="path5825"
+       inkscape:label="small right Zap"
+       sodipodi:nodetypes="ccccccc" />
+  </g>
+</svg>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,137 @@
+let statusData = {};
+let countdownInterval = null;
+
+async function fetchStatus() {
+    try {
+        const response = await fetch('/api/status');
+        if (response.ok) {
+            statusData = await response.json();
+            updateUI();
+        }
+    } catch (error) {
+        console.error("Failed to fetch status:", error);
+    }
+}
+
+function updateUI() {
+    // 1. Status Badge
+    const badge = document.getElementById('status-badge');
+    const badgeText = badge.querySelector('.status-text');
+    
+    if (statusData.enabled) {
+        if (statusData.vpn_connected && statusData.handshake === 'active') {
+            badge.className = 'status-badge active';
+            badgeText.textContent = 'TUNNEL ACTIVE';
+        } else {
+            badge.className = 'status-badge inactive';
+            badgeText.textContent = 'CONNECTING / STALE';
+        }
+    } else {
+        badge.className = 'status-badge inactive';
+        badgeText.textContent = 'TUNNEL DISABLED';
+    }
+
+    // 2. Properties
+    document.getElementById('val-public-ip').textContent = statusData.public_ip || 'None';
+    document.getElementById('val-vpn-port').textContent = statusData.vpn_port || 'None';
+    document.getElementById('val-pubkey').textContent = statusData.pubkey || 'None';
+    document.getElementById('val-pubkey').title = statusData.pubkey || 'None';
+    
+    document.getElementById('val-octet').textContent = statusData.internal_octet || 'Unknown';
+    // 3. Highlighted guide config parameters
+    const ipElements = document.querySelectorAll('.highlight-ip');
+    const portElements = document.querySelectorAll('.highlight-port');
+    
+    ipElements.forEach(el => el.textContent = statusData.public_ip || '<TunnelSats IP>');
+    portElements.forEach(el => el.textContent = statusData.vpn_port || '<Forwarding Port>');
+
+    // 4. Expiry / Countdown
+    if (countdownInterval) clearInterval(countdownInterval);
+    
+    const expiryRaw = document.getElementById('expiry-date-raw');
+    const timerEl = document.getElementById('countdown-timer');
+    const progressEl = document.getElementById('subscription-progress');
+    
+    if (statusData.expires_at && statusData.expires_at !== 'Unknown') {
+        const expiryDate = new Date(statusData.expires_at);
+        expiryRaw.textContent = expiryDate.toLocaleString();
+        
+        // Start countdown
+        countdownInterval = setInterval(() => {
+            const now = new Date();
+            const timeDiff = expiryDate - now;
+            
+            if (timeDiff <= 0) {
+                timerEl.textContent = "Expired";
+                timerEl.style.color = '#ff7b72';
+                progressEl.style.width = '0%';
+                clearInterval(countdownInterval);
+            } else {
+                const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
+                const hours = Math.floor((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+                const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
+                const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000);
+                
+                if (days > 0) {
+                    timerEl.textContent = `${days}d ${hours}h ${minutes}m`;
+                } else {
+                    timerEl.textContent = `${hours}h ${minutes}m ${seconds}s`;
+                }
+                
+                // Progress Bar (assume 30 days max subscription)
+                const maxTerm = 30 * 24 * 60 * 60 * 1000;
+                const percentage = Math.min(100, Math.max(0, (timeDiff / maxTerm) * 100));
+                progressEl.style.width = `${percentage}%`;
+            }
+        }, 1000);
+    } else {
+        expiryRaw.textContent = 'Unconfigured / Inactive';
+        timerEl.textContent = 'No Active Subscription';
+        progressEl.style.width = '0%';
+    }
+}
+
+function copyText(elementId, btn) {
+    const text = document.getElementById(elementId).title || document.getElementById(elementId).textContent;
+    navigator.clipboard.writeText(text).then(() => {
+        const originalText = btn.textContent;
+        btn.textContent = 'Copied!';
+        btn.classList.add('copied');
+        setTimeout(() => {
+            btn.textContent = originalText;
+            btn.classList.remove('copied');
+        }, 1500);
+    });
+}
+
+function copyCode(elementId, btn) {
+    const text = document.getElementById(elementId).textContent;
+    navigator.clipboard.writeText(text).then(() => {
+        const originalText = btn.textContent;
+        btn.textContent = 'Copied Block!';
+        btn.classList.add('copied');
+        setTimeout(() => {
+            btn.textContent = originalText;
+            btn.classList.remove('copied');
+        }, 1500);
+    });
+}
+
+function switchTab(tabId, btn) {
+    // Hide all tab contents
+    document.querySelectorAll('.tab-content').forEach(tab => {
+        tab.classList.remove('active');
+    });
+    // Remove active class from buttons
+    document.querySelectorAll('.tab-btn').forEach(button => {
+        button.classList.remove('active');
+    });
+    // Show selected tab content
+    document.getElementById(tabId).classList.add('active');
+    // Set active class on button
+    btn.classList.add('active');
+}
+
+// Initial fetch and set interval
+fetchStatus();
+setInterval(fetchStatus, 15000);

--- a/web/script.js
+++ b/web/script.js
@@ -67,6 +67,7 @@ function updateUI() {
                 progressEl.style.width = '0%';
                 clearInterval(countdownInterval);
             } else {
+                timerEl.style.color = '';
                 const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
                 const hours = Math.floor((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
                 const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
@@ -91,30 +92,52 @@ function updateUI() {
     }
 }
 
+function handleCopySuccess(btn, successText) {
+    const originalText = btn.textContent;
+    btn.textContent = successText;
+    btn.classList.add('copied');
+    setTimeout(() => {
+        btn.textContent = originalText;
+        btn.classList.remove('copied');
+    }, 1500);
+}
+
+function executeCopy(text, btn, successText) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(() => {
+            handleCopySuccess(btn, successText);
+        }).catch(() => {
+            fallbackCopy(text, btn, successText);
+        });
+    } else {
+        fallbackCopy(text, btn, successText);
+    }
+}
+
+function fallbackCopy(text, btn, successText) {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+        document.execCommand("copy");
+        handleCopySuccess(btn, successText);
+    } catch (err) {
+        console.error("Fallback copy failed", err);
+    }
+    document.body.removeChild(textarea);
+}
+
 function copyText(elementId, btn) {
     const text = document.getElementById(elementId).title || document.getElementById(elementId).textContent;
-    navigator.clipboard.writeText(text).then(() => {
-        const originalText = btn.textContent;
-        btn.textContent = 'Copied!';
-        btn.classList.add('copied');
-        setTimeout(() => {
-            btn.textContent = originalText;
-            btn.classList.remove('copied');
-        }, 1500);
-    });
+    executeCopy(text, btn, "Copied!");
 }
 
 function copyCode(elementId, btn) {
     const text = document.getElementById(elementId).textContent;
-    navigator.clipboard.writeText(text).then(() => {
-        const originalText = btn.textContent;
-        btn.textContent = 'Copied Block!';
-        btn.classList.add('copied');
-        setTimeout(() => {
-            btn.textContent = originalText;
-            btn.classList.remove('copied');
-        }, 1500);
-    });
+    executeCopy(text, btn, "Copied Block!");
 }
 
 function switchTab(tabId, btn) {

--- a/web/script.js
+++ b/web/script.js
@@ -54,37 +54,43 @@ function updateUI() {
     
     if (statusData.expires_at && statusData.expires_at !== 'Unknown') {
         const expiryDate = new Date(statusData.expires_at);
-        expiryRaw.textContent = expiryDate.toLocaleString();
-        
-        // Start countdown
-        countdownInterval = setInterval(() => {
-            const now = new Date();
-            const timeDiff = expiryDate - now;
+        if (!isNaN(expiryDate.getTime())) {
+            expiryRaw.textContent = expiryDate.toLocaleString();
             
-            if (timeDiff <= 0) {
-                timerEl.textContent = "Expired";
-                timerEl.style.color = '#ff7b72';
-                progressEl.style.width = '0%';
-                clearInterval(countdownInterval);
-            } else {
-                timerEl.style.color = '';
-                const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
-                const hours = Math.floor((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-                const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
-                const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000);
+            // Start countdown
+            countdownInterval = setInterval(() => {
+                const now = new Date();
+                const timeDiff = expiryDate - now;
                 
-                if (days > 0) {
-                    timerEl.textContent = `${days}d ${hours}h ${minutes}m`;
+                if (timeDiff <= 0) {
+                    timerEl.textContent = "Expired";
+                    timerEl.style.color = '#ff7b72';
+                    progressEl.style.width = '0%';
+                    clearInterval(countdownInterval);
                 } else {
-                    timerEl.textContent = `${hours}h ${minutes}m ${seconds}s`;
+                    timerEl.style.color = '';
+                    const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
+                    const hours = Math.floor((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+                    const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
+                    const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000);
+                    
+                    if (days > 0) {
+                        timerEl.textContent = `${days}d ${hours}h ${minutes}m`;
+                    } else {
+                        timerEl.textContent = `${hours}h ${minutes}m ${seconds}s`;
+                    }
+                    
+                    // Progress Bar (assume 30 days max subscription)
+                    const maxTerm = 30 * 24 * 60 * 60 * 1000;
+                    const percentage = Math.min(100, Math.max(0, (timeDiff / maxTerm) * 100));
+                    progressEl.style.width = `${percentage}%`;
                 }
-                
-                // Progress Bar (assume 30 days max subscription)
-                const maxTerm = 30 * 24 * 60 * 60 * 1000;
-                const percentage = Math.min(100, Math.max(0, (timeDiff / maxTerm) * 100));
-                progressEl.style.width = `${percentage}%`;
-            }
-        }, 1000);
+            }, 1000);
+        } else {
+            expiryRaw.textContent = 'Invalid Expiry Date';
+            timerEl.textContent = 'No Active Subscription';
+            progressEl.style.width = '0%';
+        }
     } else {
         expiryRaw.textContent = 'Unconfigured / Inactive';
         timerEl.textContent = 'No Active Subscription';

--- a/web/script.js
+++ b/web/script.js
@@ -1,5 +1,6 @@
 let statusData = {};
 let countdownInterval = null;
+let targetExpiry = null;
 
 async function fetchStatus() {
     try {
@@ -46,55 +47,62 @@ function updateUI() {
     portElements.forEach(el => el.textContent = statusData.vpn_port || '<Forwarding Port>');
 
     // 4. Expiry / Countdown
-    if (countdownInterval) clearInterval(countdownInterval);
-    
     const expiryRaw = document.getElementById('expiry-date-raw');
     const timerEl = document.getElementById('countdown-timer');
     const progressEl = document.getElementById('subscription-progress');
     
     if (statusData.expires_at && statusData.expires_at !== 'Unknown') {
-        const expiryDate = new Date(statusData.expires_at);
-        if (!isNaN(expiryDate.getTime())) {
-            expiryRaw.textContent = expiryDate.toLocaleString();
-            
-            // Start countdown
-            countdownInterval = setInterval(() => {
-                const now = new Date();
-                const timeDiff = expiryDate - now;
-                
-                if (timeDiff <= 0) {
-                    timerEl.textContent = "Expired";
-                    timerEl.style.color = '#ff7b72';
-                    progressEl.style.width = '0%';
-                    clearInterval(countdownInterval);
-                } else {
-                    timerEl.style.color = '';
-                    const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
-                    const hours = Math.floor((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-                    const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
-                    const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000);
-                    
-                    if (days > 0) {
-                        timerEl.textContent = `${days}d ${hours}h ${minutes}m`;
-                    } else {
-                        timerEl.textContent = `${hours}h ${minutes}m ${seconds}s`;
-                    }
-                    
-                    // Progress Bar (assume 30 days max subscription)
-                    const maxTerm = 30 * 24 * 60 * 60 * 1000;
-                    const percentage = Math.min(100, Math.max(0, (timeDiff / maxTerm) * 100));
-                    progressEl.style.width = `${percentage}%`;
-                }
-            }, 1000);
+        const parsedDate = new Date(statusData.expires_at);
+        if (!isNaN(parsedDate.getTime())) {
+            expiryRaw.textContent = parsedDate.toLocaleString();
+            targetExpiry = parsedDate;
         } else {
+            targetExpiry = null;
             expiryRaw.textContent = 'Invalid Expiry Date';
             timerEl.textContent = 'No Active Subscription';
             progressEl.style.width = '0%';
         }
     } else {
+        targetExpiry = null;
         expiryRaw.textContent = 'Unconfigured / Inactive';
         timerEl.textContent = 'No Active Subscription';
         progressEl.style.width = '0%';
+    }
+
+    if (!countdownInterval) {
+        countdownInterval = setInterval(() => {
+            if (!targetExpiry) return;
+            
+            const now = new Date();
+            const timeDiff = targetExpiry - now;
+            
+            const tEl = document.getElementById('countdown-timer');
+            const pEl = document.getElementById('subscription-progress');
+            if (!tEl || !pEl) return;
+            
+            if (timeDiff <= 0) {
+                tEl.textContent = "Expired";
+                tEl.style.color = '#ff7b72';
+                pEl.style.width = '0%';
+            } else {
+                tEl.style.color = '';
+                const days = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
+                const hours = Math.floor((timeDiff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+                const minutes = Math.floor((timeDiff % (1000 * 60 * 60)) / (1000 * 60));
+                const seconds = Math.floor((timeDiff % (1000 * 60)) / 1000);
+                
+                if (days > 0) {
+                    tEl.textContent = `${days}d ${hours}h ${minutes}m`;
+                } else {
+                    tEl.textContent = `${hours}h ${minutes}m ${seconds}s`;
+                }
+                
+                // Progress Bar (assume 30 days max subscription)
+                const maxTerm = 30 * 24 * 60 * 60 * 1000;
+                const percentage = Math.min(100, Math.max(0, (timeDiff / maxTerm) * 100));
+                pEl.style.width = `${percentage}%`;
+            }
+        }, 1000);
     }
 }
 

--- a/web/script.js
+++ b/web/script.js
@@ -132,6 +132,53 @@ function switchTab(tabId, btn) {
     btn.classList.add('active');
 }
 
+// ─────────────────────────────────────────────
+// FAQ Modal
+// ─────────────────────────────────────────────
+
+const faqModal = document.getElementById('faq-modal');
+
+function openFaqModal() {
+    if (faqModal) {
+        faqModal.showModal();
+        // Trap focus within modal on open
+        faqModal.querySelector('.faq-close-btn').focus();
+    }
+}
+
+function closeFaqModal() {
+    if (faqModal) {
+        // Animate out then close
+        const inner = faqModal.querySelector('.faq-dialog-inner');
+        if (inner) {
+            inner.style.animation = 'faq-slide-in 0.18s cubic-bezier(0.4, 0, 1, 1) reverse both';
+            setTimeout(() => {
+                faqModal.close();
+                inner.style.animation = '';
+            }, 160);
+        } else {
+            faqModal.close();
+        }
+    }
+}
+
+// Close when clicking the backdrop (outside .faq-dialog-inner)
+if (faqModal) {
+    faqModal.addEventListener('click', (e) => {
+        // The dialog element itself is the backdrop area
+        if (e.target === faqModal) {
+            closeFaqModal();
+        }
+    });
+
+    // Native Escape key support is built into <dialog>, but we hook it
+    // to use our animated close instead of the abrupt browser default
+    faqModal.addEventListener('cancel', (e) => {
+        e.preventDefault();
+        closeFaqModal();
+    });
+}
+
 // Initial fetch and set interval
 fetchStatus();
 setInterval(fetchStatus, 15000);

--- a/web/style.css
+++ b/web/style.css
@@ -511,17 +511,23 @@ code {
     border: none;
     padding: 0;
     background: transparent;
-    /* Full-screen overlay */
+    /* Full-screen overlay positioning */
     position: fixed;
     inset: 0;
     width: 100%;
     height: 100%;
     max-width: 100%;
     max-height: 100%;
+    z-index: 1000;
+    /* NOTE: do NOT set display: flex here — it overrides the browser's
+       native display:none for a closed <dialog>. Flex is set on [open]. */
+}
+
+/* Only apply flex-centering when the dialog is actually open */
+.faq-modal[open] {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 1000;
 }
 
 /* Backdrop via the native ::backdrop pseudo-element */
@@ -790,7 +796,7 @@ code {
         right: 0;
         max-width: 100%;
     }
-    .faq-modal {
+    .faq-modal[open] {
         align-items: flex-end;
     }
 }

--- a/web/style.css
+++ b/web/style.css
@@ -447,32 +447,350 @@ code {
     color: var(--accent-bitcoin);
 }
 
-/* Footer styling */
+/* ──────────────────────────────────────────────────────
+   Footer
+────────────────────────────────────────────────────── */
 .dashboard-footer {
     text-align: center;
+    margin-top: 12px;
+    padding-bottom: 4px;
+}
+
+.footer-links {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.footer-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12.5px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    text-decoration: none;
+    padding: 4px 8px;
+    border-radius: 6px;
+    transition: color 0.2s ease, background 0.2s ease;
+    cursor: pointer;
+}
+
+.footer-link:hover {
+    color: var(--accent-bitcoin);
+    background: var(--accent-bitcoin-glow);
+}
+
+.footer-link-icon {
+    width: 13px;
+    height: 13px;
+    flex-shrink: 0;
+}
+
+.footer-divider {
+    color: rgba(156, 163, 175, 0.35);
+    font-size: 13px;
+    user-select: none;
+}
+
+/* FAQ trigger button — reset browser button defaults */
+.footer-btn-faq {
+    background: none;
+    border: none;
+    font-family: inherit;
+}
+
+/* ──────────────────────────────────────────────────────
+   FAQ Modal — native <dialog> with glassmorphism
+────────────────────────────────────────────────────── */
+
+.faq-modal {
+    /* Reset browser defaults */
+    border: none;
+    padding: 0;
+    background: transparent;
+    /* Full-screen overlay */
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+/* Backdrop via the native ::backdrop pseudo-element */
+.faq-modal::backdrop {
+    background: rgba(0, 0, 0, 0.72);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+/* The glass card container inside the dialog */
+.faq-dialog-inner {
+    width: 100%;
+    max-width: 680px;
+    max-height: 82vh;
+    display: flex;
+    flex-direction: column;
+    background: rgba(14, 18, 27, 0.92);
+    border: 1px solid rgba(250, 204, 21, 0.18);
+    border-radius: 18px;
+    box-shadow:
+        0 0 0 1px rgba(250, 204, 21, 0.06),
+        0 24px 64px rgba(0, 0, 0, 0.7),
+        0 0 60px -10px rgba(250, 204, 21, 0.08);
+    overflow: hidden;
+    animation: faq-slide-in 0.28s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@keyframes faq-slide-in {
+    from {
+        opacity: 0;
+        transform: translateY(18px) scale(0.97);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* Header bar */
+.faq-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 24px 16px;
+    border-bottom: 1px solid rgba(31, 41, 55, 0.9);
+    flex-shrink: 0;
+    background: rgba(250, 204, 21, 0.03);
+}
+
+.faq-modal-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.faq-title-icon {
+    width: 20px;
+    height: 20px;
+    color: var(--accent-bitcoin);
+    flex-shrink: 0;
+}
+
+.faq-modal-header h2 {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: 0.01em;
+}
+
+.faq-close-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: all 0.15s ease;
+    flex-shrink: 0;
+}
+
+.faq-close-btn svg {
+    width: 15px;
+    height: 15px;
+}
+
+.faq-close-btn:hover {
+    background: rgba(239, 68, 68, 0.15);
+    border-color: rgba(239, 68, 68, 0.3);
+    color: #ef4444;
+}
+
+/* Scrollable body */
+.faq-body {
+    overflow-y: auto;
+    padding: 8px 8px 16px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(250, 204, 21, 0.2) transparent;
+}
+
+.faq-body::-webkit-scrollbar {
+    width: 4px;
+}
+.faq-body::-webkit-scrollbar-track {
+    background: transparent;
+}
+.faq-body::-webkit-scrollbar-thumb {
+    background: rgba(250, 204, 21, 0.25);
+    border-radius: 2px;
+}
+
+/* ── Accordion items ── */
+.faq-item {
+    border-radius: 10px;
+    margin: 4px 0;
+    overflow: hidden;
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease;
+}
+
+.faq-item[open] {
+    border-color: rgba(250, 204, 21, 0.2);
+    background: rgba(250, 204, 21, 0.03);
+}
+
+.faq-question {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--text-primary);
+    cursor: pointer;
+    border-radius: 10px;
+    user-select: none;
+    transition: background 0.15s ease, color 0.15s ease;
+    gap: 12px;
+}
+
+/* Remove the native disclosure triangle */
+.faq-question::-webkit-details-marker { display: none; }
+.faq-question::marker { display: none; }
+
+/* Custom chevron via pseudo-element */
+.faq-question::after {
+    content: '';
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%239ca3af' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: contain;
+    transition: transform 0.22s ease;
+}
+
+.faq-item[open] > .faq-question::after {
+    transform: rotate(180deg);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23facc15' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+}
+
+.faq-item[open] > .faq-question {
+    color: var(--accent-bitcoin);
+}
+
+.faq-question:hover {
+    background: rgba(250, 204, 21, 0.05);
+    color: var(--accent-bitcoin);
+}
+
+/* Answer content */
+.faq-answer {
+    padding: 0 16px 16px 16px;
+    border-top: 1px solid rgba(31, 41, 55, 0.6);
+    margin-top: 0;
+}
+
+.faq-answer p,
+.faq-answer ol,
+.faq-answer ul {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.65;
     margin-top: 10px;
 }
 
-.dashboard-footer p {
-    font-size: 12.5px;
-    color: var(--text-secondary);
+.faq-answer ol,
+.faq-answer ul {
+    padding-left: 18px;
 }
 
-.dashboard-footer a {
+.faq-answer li {
+    margin-top: 5px;
+}
+
+.faq-answer code {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11.5px;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 4px;
+    padding: 1px 5px;
+    color: var(--accent-bitcoin);
+}
+
+.faq-answer a {
     color: var(--accent-bitcoin);
     text-decoration: none;
-    font-weight: 600;
+    font-weight: 500;
 }
 
-.dashboard-footer a:hover {
+.faq-answer a:hover {
     text-decoration: underline;
 }
 
+.faq-answer strong {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.faq-note {
+    background: rgba(250, 204, 21, 0.05);
+    border-left: 3px solid rgba(250, 204, 21, 0.4);
+    border-radius: 0 6px 6px 0;
+    padding: 8px 12px;
+    font-size: 12px !important;
+    margin-top: 12px !important;
+}
+
+/* CTA link inside FAQ answer */
+.faq-cta-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--accent-bitcoin);
+    text-decoration: none;
+    border-bottom: 1px solid rgba(250, 204, 21, 0.3);
+    padding-bottom: 1px;
+    transition: border-color 0.15s ease;
+}
+
+.faq-cta-link:hover {
+    border-color: var(--accent-bitcoin);
+}
+
+/* ── Responsive ── */
 @media (max-width: 768px) {
     .dashboard-grid {
         grid-template-columns: 1fr;
     }
     .span-2 {
         grid-column: span 1;
+    }
+    .faq-dialog-inner {
+        max-height: 90vh;
+        border-radius: 16px 16px 0 0;
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        max-width: 100%;
+    }
+    .faq-modal {
+        align-items: flex-end;
     }
 }

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,478 @@
+:root {
+    --bg-color: #0f1115;
+    --card-bg: rgba(17, 24, 39, 0.4);
+    --card-border: rgba(31, 41, 55, 0.8);
+    --text-primary: #f3f4f6;
+    --text-secondary: #9ca3af;
+    --accent-bitcoin: #facc15;
+    --accent-bitcoin-glow: rgba(250, 204, 21, 0.12);
+    --accent-signal: #22c55e;
+    --accent-signal-glow: rgba(34, 197, 94, 0.15);
+    --accent-alert: #ef4444;
+    --accent-alert-glow: rgba(239, 68, 68, 0.15);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    background-color: var(--bg-color);
+    color: var(--text-primary);
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    min-height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow-x: hidden;
+    position: relative;
+    padding: 20px;
+}
+
+/* Background glowing circles */
+.background-glow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle, var(--accent-bitcoin-glow) 0%, var(--accent-signal-glow) 50%, rgba(15, 17, 21, 0) 100%);
+    z-index: 1;
+    pointer-events: none;
+    filter: blur(80px);
+}
+
+.dashboard-container {
+    width: 100%;
+    max-width: 900px;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+/* Header styling */
+.dashboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 10px;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+}
+
+.brand-logo {
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
+}
+
+.brand-text h1 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: -0.5px;
+    background: linear-gradient(135deg, var(--accent-bitcoin) 0%, #d99015 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.brand-text .subtext {
+    font-size: 13px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+/* Status badge */
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-radius: 100px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    transition: all 0.3s ease;
+}
+
+.status-badge.active {
+    background: rgba(34, 197, 94, 0.1);
+    color: var(--accent-signal);
+    box-shadow: 0 0 12px var(--accent-signal-glow);
+    border-color: rgba(34, 197, 94, 0.3);
+}
+
+.status-badge.inactive {
+    background: rgba(239, 68, 68, 0.1);
+    color: var(--accent-alert);
+    box-shadow: 0 0 12px var(--accent-alert-glow);
+    border-color: rgba(239, 68, 68, 0.25);
+}
+
+.pulse-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: currentColor;
+    display: inline-block;
+}
+
+.active .pulse-dot {
+    animation: pulse 1.8s infinite;
+}
+
+@keyframes pulse {
+    0% {
+        box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.7);
+    }
+    70% {
+        box-shadow: 0 0 0 8px rgba(34, 197, 94, 0);
+    }
+    100% {
+        box-shadow: 0 0 0 0 rgba(34, 197, 94, 0);
+    }
+}
+
+/* Card components */
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
+}
+
+.span-2 {
+    grid-column: span 2;
+}
+
+.card {
+    border-radius: 16px;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.glass-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    backdrop-filter: blur(12px) saturate(180%);
+    box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.glass-card:hover {
+    border-color: rgba(250, 204, 21, 0.3);
+    box-shadow: 0 8px 32px 0 rgba(250, 204, 21, 0.05);
+}
+
+.card h2 {
+    font-family: 'Outfit', sans-serif;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* Subscription Card custom styling */
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.info-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.05);
+    padding: 4px 10px;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.subscription-content {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.countdown-container {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.countdown-label {
+    font-size: 11px;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.countdown-timer {
+    font-family: 'Outfit', sans-serif;
+    font-size: 32px;
+    font-weight: 700;
+    background: linear-gradient(135deg, var(--text-primary) 30%, var(--accent-bitcoin) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.progress-bar-container {
+    width: 100%;
+    height: 6px;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 10px;
+    overflow: hidden;
+}
+
+.progress-bar {
+    height: 100%;
+    background: linear-gradient(90deg, #d99015 0%, var(--accent-bitcoin) 100%);
+    border-radius: 10px;
+    transition: width 1s ease-in-out;
+}
+
+/* Properties Grid custom styling */
+.properties-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 16px;
+}
+
+@media (max-width: 600px) {
+    .properties-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.prop-item {
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.02);
+    padding: 14px;
+    border-radius: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.prop-label {
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.prop-value-group {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.prop-value {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13.5px;
+    color: var(--text-primary);
+    word-break: break-all;
+}
+
+.prop-value.truncated {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 180px;
+}
+
+.btn-copy {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: var(--text-primary);
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-copy:hover {
+    background: rgba(250, 204, 21, 0.05);
+    border-color: var(--accent-bitcoin);
+    color: var(--accent-bitcoin);
+}
+
+.btn-copy.copied {
+    background: rgba(34, 197, 94, 0.1);
+    border-color: var(--accent-signal);
+    color: var(--accent-signal);
+}
+
+/* Documentation / Tabs custom styling */
+.docs-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    padding-bottom: 14px;
+}
+
+.tabs {
+    display: flex;
+    gap: 8px;
+    background: rgba(0, 0, 0, 0.2);
+    padding: 3px;
+    border-radius: 8px;
+}
+
+.tab-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    padding: 6px 14px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.tab-btn:hover {
+    color: var(--text-primary);
+}
+
+.tab-btn.active {
+    background: rgba(250, 204, 21, 0.08);
+    color: var(--accent-bitcoin);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    border: 1px solid rgba(250, 204, 21, 0.15);
+}
+
+.tab-content {
+    display: none;
+    flex-direction: column;
+    gap: 14px;
+    animation: fadeIn 0.3s ease;
+}
+
+.tab-content.active {
+    display: flex;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.guide-intro {
+    font-size: 13.5px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+.code-block-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: var(--text-secondary);
+}
+
+pre {
+    background: #0b0d11;
+    border: 1px solid rgba(255, 255, 255, 0.03);
+    padding: 16px;
+    border-radius: 10px;
+    overflow-x: auto;
+}
+
+code {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 13px;
+    color: var(--text-primary);
+    line-height: 1.5;
+}
+
+.highlight-ip, .highlight-port {
+    font-weight: 600;
+    color: var(--accent-bitcoin);
+    background: rgba(250, 204, 21, 0.08);
+    padding: 1px 4px;
+    border-radius: 4px;
+}
+
+.btn-copy-code {
+    background: rgba(250, 204, 21, 0.05);
+    border: 1px solid rgba(250, 204, 21, 0.2);
+    color: var(--accent-bitcoin);
+    padding: 5px 12px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.btn-copy-code:hover {
+    background: rgba(250, 204, 21, 0.1);
+    border-color: var(--accent-bitcoin);
+}
+
+.btn-copy-code.copied {
+    background: rgba(34, 197, 94, 0.15);
+    border-color: var(--accent-signal);
+    color: var(--accent-signal);
+}
+
+.warning-box {
+    background: rgba(250, 204, 21, 0.02);
+    border-left: 3px solid var(--accent-bitcoin);
+    padding: 12px;
+    border-radius: 0 8px 8px 0;
+    font-size: 12.5px;
+    color: var(--text-secondary);
+    line-height: 1.4;
+}
+
+.warning-box strong {
+    color: var(--accent-bitcoin);
+}
+
+/* Footer styling */
+.dashboard-footer {
+    text-align: center;
+    margin-top: 10px;
+}
+
+.dashboard-footer p {
+    font-size: 12.5px;
+    color: var(--text-secondary);
+}
+
+.dashboard-footer a {
+    color: var(--accent-bitcoin);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.dashboard-footer a:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
+    .span-2 {
+        grid-column: span 1;
+    }
+}


### PR DESCRIPTION
# PR: feat/v0.2.0-dashboard-toggle-expiry

## Summary of Changes
- **Web Dashboard:** Added a premium, modern dashboard UI to monitor WireGuard connectivity, subscription status, and copy configuration parameters.
- **Subscription Tracking:** Implemented automated background sync (`lazy_sync`) to query the TunnelSats status coordinator and update subscription expiry.
- **On/Off Toggle:** Added support in `bridge.py` and `config_spec.yaml` to allow starting/stopping the tunnel.
- **FAQ Accordion:** Added a native, responsive FAQ dialog answering common user onboarding and troubleshooting questions.
- **Greptile Review Fixes:** Addressed security (CORS wildcard removal), logging (transparent User-Agent), and portability issues.

## Testing Strategy
- **Unit Tests:** 29/29 tests passing successfully.
- **Verification:** SOCKS5 outbound routing and inbound port check are fully validated on live node.

## Caveat / Warning
- **Do Not Use Yet (README):** Kept the README status as 'Do not use' for now, waiting for LND / CLN manual inbound checks to confirm 100% channel gossip routing stability.
